### PR TITLE
test(api): close out Option-A track — defer workflow/load, restore compliance coverage gate (#624 PR3/4/5)

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -47,13 +47,32 @@ module.exports = {
     '!**/logs/**'
   ],
 
-  // Coverage thresholds removed as part of #623 B-auth slice. The original
-  // thresholds referenced files (complianceService.js, pipelineService.js,
-  // phase2-endpoints.js) whose coverage comes from the suites skipped in this
-  // PR — leaving the thresholds in place caused Jest's CoverageReporter to
-  // crash (Vikunja #632) and CI to exit non-zero despite all running tests
-  // passing. Restore both the global (80%) and per-file (85-90%) thresholds
-  // as part of Option A (Vikunja #624) when those suites are un-skipped.
+  // Coverage thresholds — partial restoration as part of Option A PR5 (#635).
+  //
+  // The original pre-B-auth config enforced 80% global + 85-90% per-file on
+  // complianceService.js / pipelineService.js / phase2-endpoints.js. Those
+  // targets assumed all 4 deferred suites would provide the coverage —
+  // workflow.test.js + load.test.js are now deferred indefinitely (#656/#657),
+  // so the 80/90/85 values are unachievable without a broader testing strategy.
+  //
+  // We restore a single gate on complianceService.js — the file PR2 (#655)
+  // actually exercises well — at values ~3pt under current reality so small
+  // refactors don't flake the suite. Global, pipelineService, and
+  // phase2-endpoints thresholds stay off until workflow un-skip (#656) or a
+  // dedicated unit-test push raises their coverage. Re-open #635 if thresholds
+  // need to be tightened or extended.
+  //
+  // Prerequisite: glob@7 override scoped to @jest/reporters (see package.json)
+  // — keeps #632's CoverageReporter crash from recurring now that the
+  // threshold is back.
+  coverageThreshold: {
+    './services/compliance/complianceService.js': {
+      statements: 75,
+      branches: 55,
+      functions: 70,
+      lines: 78,
+    },
+  },
 
 
   // Coverage reporting

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1977,6 +1977,28 @@
         }
       }
     },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -5223,6 +5245,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5578,6 +5607,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -7489,6 +7530,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {

--- a/api/package.json
+++ b/api/package.json
@@ -56,6 +56,9 @@
     "@smithy/config-resolver": "^4.4.6",
     "minimatch": "^10.2.1",
     "glob": "^11.0.0",
+    "@jest/reporters": {
+      "glob": "^7.2.3"
+    },
     "rimraf": "^6.0.0",
     "fast-xml-parser": "^5.5.7",
     "picomatch": "^4.0.4",

--- a/api/tests/integration/workflow.test.js
+++ b/api/tests/integration/workflow.test.js
@@ -9,13 +9,33 @@ const { setupGitHubMock, resetGitHubMock } = require('../mocks/github');
 // Import the phase2 router
 const phase2Router = require('../../phase2-endpoints');
 
-// SKIP: awaiting Option-A refactor (createApp factory + AuthService DI +
-// compliance persistence decision). This suite exercises end-to-end
-// workflow across compliance + pipelines + orchestrations tables, none
-// of which exist in the production Database schema.
-// Tracking: Vikunja #624.
-// Design: docs/plans/2026-04-20-api-test-restoration-b-auth.md
-//         docs/plans/2026-04-20-option-a-createapp-di.md (un-skip plan — PR 3 of #624)
+// SKIP: deferred from the sequential Option-A un-skip track.
+//
+// A 2026-04-20 contract audit (after PR1+PR2 landed the createApp/DI
+// foundation) showed this suite asserts response shapes and WebSocket
+// event names that the real service/route layer does not produce. It's
+// not an un-skip PR — it's a contract-alignment effort that needs its
+// own brainstorming pass.
+//
+// Representative gaps:
+//   - orchestration routes return {success, orchestration: {...}} (nested)
+//     but tests expect top-level {orchestrationId, status, results}
+//   - /api/v2/status returns a platform-health snapshot
+//     ({platformVersion, phase, components}) but tests expect an
+//     aggregate data shape ({pipelines, compliance, metrics})
+//   - WS events emitted as compliance:checked / pipeline:triggered but
+//     tests listen for compliance:updated / pipeline:status
+//   - /compliance/check is async (jobId) but test expects sync
+//     {compliance: {score, status}}
+//   - /compliance/apply returns {repository, templates, results, ...}
+//     but test expects {success: true, prUrl}
+//
+// Tracking: Vikunja #656 (this bead) + discovery tasks #661 (compliance
+// sync), #660 (compliance apply/history shapes), #665 (orchestration
+// shapes), #666 (/api/v2/status shape), #667 (WS event naming).
+//
+// Design: docs/plans/2026-04-20-option-a-createapp-di.md (un-skip plan —
+//         PR 3 of #624; deferred 2026-04-20)
 describe.skip('End-to-End Workflow Integration', () => {
   let app;
   let httpServer;

--- a/api/tests/performance/load.test.js
+++ b/api/tests/performance/load.test.js
@@ -7,13 +7,24 @@ const { setupGitHubMock, resetGitHubMock } = require('../mocks/github');
 // Import the phase2 router
 const phase2Router = require('../../phase2-endpoints');
 
-// SKIP: awaiting Option-A refactor (createApp factory + AuthService DI +
-// compliance persistence decision). Performance suite wires phase2Router
-// without app.locals — crashes before any benchmark runs. Needs the
-// Option-A app factory.
-// Tracking: Vikunja #624.
-// Design: docs/plans/2026-04-20-api-test-restoration-b-auth.md
-//         docs/plans/2026-04-20-option-a-createapp-di.md (un-skip plan — PR 4 of #624)
+// SKIP: deferred from the sequential Option-A un-skip track.
+//
+// A 2026-04-20 audit (after PR1+PR2 landed) showed this suite's scope
+// is wrong for jest. It asserts hard timing thresholds (avg < 200ms,
+// max < 500ms, memory growth < 50%, "500-record dataset in < 1s") that
+// are CI-runner-dependent and flake-prone — landing red CI on timing
+// trains reviewers to ignore failures, which is worse than no perf test.
+//
+// Architectural mismatches also exist (pipelineService reads from
+// githubMCP not a DB, so "large dataset" has no meaningful fake shape;
+// rate-limiting middleware is off in dev/test mode; WS naming is
+// inconsistent — see #667).
+//
+// Tracking: Vikunja #657 (this bead) + discovery task #668 (move perf
+// tests to a dedicated harness — k6/autocannon — not jest).
+//
+// Design: docs/plans/2026-04-20-option-a-createapp-di.md (un-skip plan —
+//         PR 4 of #624; deferred 2026-04-20)
 describe.skip('Performance and Load Testing', () => {
   let app;
   let adminToken;


### PR DESCRIPTION
## Summary

Closes out the sequential Option-A un-skip track. PRs 3 and 4 (workflow + load) are **deferred** — contract audits showed neither is a straight un-skip. PR 5 (coverageThreshold) is **landed** in scaled-down form. Closes **#635** and **#632**; leaves **#624** open pending workflow/load follow-through.

## What changed

### 1. Deferred PR 3 — `workflow.test.js` (Vikunja #656)

The suite asserts contracts the implementation doesn't produce. Discovery tasks filed:
- **#661** — `/compliance/check` sync vs async (same gap surfaced in PR2)
- **#660** — `/compliance/apply` + `/compliance/history` response shapes
- **#665** — orchestration response shapes (`{success, orchestration: {...}}` nesting)
- **#666** — `/api/v2/status` returns platform-health snapshot, not aggregate data
- **#667** — WS event naming (`compliance:checked` vs `compliance:updated`)

Skip comment rewritten to explain the real reason (not "awaiting DI" — DI is done).

### 2. Deferred PR 4 — `load.test.js` (Vikunja #657)

Timing assertions in jest (`avg < 200ms`, memory growth `< 50%`) are CI-runner-dependent and flake-prone. Discovery task **#668** — move perf tests to a dedicated harness (k6/autocannon) out of jest.

### 3. Scoped glob@7 override for @jest/reporters (fixes #632)

The existing top-level `glob: ^11.0.0` override was forced into `@jest/reporters`' internals. Jest 29.7's `@jest/reporters` was built expecting glob@7's CJS shape — glob@11 exports `__esModule: true` without a `.default`, so Babel's interop passes it through unchanged and `CoverageReporter` blows up on `Cannot read properties of undefined (reading 'sync')`.

Scoped override (nested `overrides` form) keeps glob@7 inside `@jest/reporters` only.

### 4. Partial coverageThreshold restoration (#635)

Single gate on `complianceService.js` at realistic values (statements: 75 / branches: 55 / functions: 70 / lines: 78 — ~3pt under current reality). Global + pipelineService + phase2-endpoints thresholds stay off until workflow un-skip or a dedicated unit-test push.

## Test plan

- [x] `cd api && npm test` → Test Suites: 2 skipped, 3 passed / Tests: 21 skipped, 54 passed / exit 0
- [x] coverageThreshold enforces on complianceService.js (tightening `lines: 78 → 99` was shown to fail; restored to 78)
- [x] No regression in realtime / pipelines / compliance
- [x] workflow + load remain skipped with updated reason comments

## Vikunja

- **Closes** #635 (coverageThreshold restoration)
- **Closes** #632 (CoverageReporter crash)
- **Deferred with updated context:** #656 (workflow un-skip), #657 (load un-skip)
- **New follow-ups filed:** #665, #666, #667, #668
- **Stays open:** #624 (umbrella — workflow/load work remains)

Design doc: `docs/plans/2026-04-20-option-a-createapp-di.md` §§3, 4, 5.