### PR TITLE
fix: add ajv + ajv-formats + lodash to root dependencies (#658)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/server-filesystem": "^2025.7.1",
         "@modelcontextprotocol/server-github": "^2025.4.8",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "axios": "^1.13.5",
         "chokidar": "^3.5.3",
         "concurrently": "^9.1.0",
@@ -18,6 +20,7 @@
         "express": "^5.2.1",
         "fs-extra": "^11.1.1",
         "glob": "^11.0.0",
+        "lodash": "^4.18.0",
         "natural": "^6.10.0",
         "node-cron": "^3.0.3",
         "node-fetch": "^3.3.2",
@@ -5101,6 +5104,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/logform": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "dependencies": {
     "@modelcontextprotocol/server-filesystem": "^2025.7.1",
     "@modelcontextprotocol/server-github": "^2025.4.8",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "axios": "^1.13.5",
     "chokidar": "^3.5.3",
     "concurrently": "^9.1.0",
@@ -54,6 +56,7 @@
     "express": "^5.2.1",
     "fs-extra": "^11.1.1",
     "glob": "^11.0.0",
+    "lodash": "^4.18.0",
     "natural": "^6.10.0",
     "node-cron": "^3.0.3",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
## Summary

Fixes **#658**. \`node api/server.js\` fails at boot with \`Cannot find module 'lodash'\` because the require chain reaches into \`config/utils/config-manager.js\`, whose deps aren't installed at workspace root.

## Root cause

Chain:

\`api/server.js\` → \`routes/wiki.js\` → \`utils/audit-logger.js\` → \`../../config/utils/config-manager.js\` → \`require('lodash')\`

Node walks up from \`config/utils/\` looking for \`node_modules/lodash\`. \`api/node_modules\` is a **sibling** of \`config/\`, not a parent — unreachable. Root \`node_modules\` has \`ajv\` + \`ajv-formats\` (transitive via \`@modelcontextprotocol/sdk\`) but **no \`lodash\`**, so boot fails on line 5 of config-manager.js.

## Fix

Add the 3 deps explicitly to root \`package.json\`:

- \`ajv ^8.18.0\` — matches \`api/package.json\`
- \`ajv-formats ^3.0.1\` — current resolved version in root tree
- \`lodash ^4.18.0\` — matches api's post-CVE override (#7500081, alerts #187/#188)

This also removes the implicit reliance on \`ajv\` being available as a transitive dep — defensive against upstream \`@modelcontextprotocol/sdk\` changes.

## Verification

- [x] \`cd api && npm rebuild sqlite3 --build-from-source\` (GLIBC workaround — task #634)
- [x] \`node api/server.js --port=3078\` → boots, logs \`🔧 GitOps Audit API running on port 3078\`
- [x] \`curl /api/v2/status\` → HTTP 200 with real JSON payload
- [x] \`curl /audit\` → HTTP 200
- [x] \`cd api && npm test\` → 54 passed / 21 skipped / exit 0 (unaffected by root-level change)

Closes #658.