### PR TITLE
test(api): lock in flat /orchestration-metrics shape (#683)

### DIFF
--- a/api/phase2-endpoints.js
+++ b/api/phase2-endpoints.js
@@ -2227,11 +2227,14 @@ phase2Router.get('/orchestration-status', async (req, res) => {
   }
 });
 
+// Response shape is flat (Vikunja #624 / #665 Decision 3, extended to this
+// legacy endpoint under #683): no `{success, metrics: {...}}` wrapper —
+// the monitor's metrics object is spread directly onto the response body.
 phase2Router.get('/orchestration-metrics', async (req, res) => {
   try {
-    const orchestrator = initializeOrchestrationService(req.app);
+    const orchestrator = req.app.locals?.orchestrator || initializeOrchestrationService(req.app);
     const metrics = orchestrator.getMetrics(req.query.timeRange || '1h');
-    
+
     res.json(metrics);
   } catch (error) {
     res.status(500).json({ error: 'Failed to get orchestration metrics', details: error.message });

--- a/api/tests/routes/orchestration.test.js
+++ b/api/tests/routes/orchestration.test.js
@@ -58,6 +58,15 @@ describe('Orchestration routes — flattened response shape (Decision 3)', () =>
       },
     }));
     orchestrator.listActiveOrchestrations = jest.fn(() => []);
+    orchestrator.getMetrics = jest.fn((timeRange = '1h') => ({
+      orchestrations: [{ id: 'orch-test-1', status: 'completed' }],
+      tasks: [{ id: 't1', status: 'completed' }],
+      system: { cpu: [], memory: [], disk: [], network: [] },
+      alerts: [],
+      performance: {},
+      timeRange,
+      generatedAt: new Date('2026-04-21T12:00:00Z'),
+    }));
 
     const calls = [];
     phase2WS = {
@@ -117,6 +126,32 @@ describe('Orchestration routes — flattened response shape (Decision 3)', () =>
       });
       expect(res.body).not.toHaveProperty('success');
       expect(res.body).not.toHaveProperty('orchestration');
+    });
+  });
+
+  describe('GET /orchestration-metrics — flat response (#683)', () => {
+    it('returns the monitor metrics flat with no `success` or `metrics` wrapper', async () => {
+      const res = await request(app)
+        .get('/api/v2/orchestration-metrics')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('orchestrations');
+      expect(res.body).toHaveProperty('tasks');
+      expect(res.body).toHaveProperty('system');
+      expect(res.body).toHaveProperty('timeRange');
+      expect(res.body).toHaveProperty('generatedAt');
+      expect(res.body).not.toHaveProperty('success');
+      expect(res.body).not.toHaveProperty('metrics');
+      expect(orchestrator.getMetrics).toHaveBeenCalledWith('1h');
+    });
+
+    it('passes req.query.timeRange through to getMetrics', async () => {
+      await request(app)
+        .get('/api/v2/orchestration-metrics?timeRange=24h')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(orchestrator.getMetrics).toHaveBeenCalledWith('24h');
     });
   });
 


### PR DESCRIPTION
## Summary

Task #683 asked to \"drop any wrapper\" on \`GET /api/v2/orchestration-metrics\` for consistency with the #665 flatten decision. Audit shows the endpoint has **always** returned a flat body (\`res.json(metrics)\`) since the initial commit — there was never a wrapper to drop.

This PR locks that contract in so future refactors can't accidentally wrap it:

1. **DI fix** — handler prefers \`req.app.locals?.orchestrator\` over the module-level singleton \`initializeOrchestrationService\`, matching the pattern already used by the \`/orchestration\` subrouter mount. Enables testability.
2. **Regression tests** — two tests in \`tests/routes/orchestration.test.js\`:
   - asserts flat body, no \`success\` / \`metrics\` wrapper
   - asserts \`?timeRange=24h\` query passthrough to \`getMetrics()\`
3. **Comment** — documents the flat contract at the handler.

## Test plan

- [x] Baseline: 10 jest suites / 104 tests pass
- [x] Post-change: 10 suites / 106 tests pass (+2 new)
- [x] Coverage thresholds still hold

Closes Vikunja #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)