### PR TITLE
refactor(api): drop legacy compliance.* WS event names (#681)

### DIFF
--- a/api/phase2-websocket.js
+++ b/api/phase2-websocket.js
@@ -69,10 +69,6 @@ class Phase2WebSocketExtension {
         description: 'Template compliance tracking and application updates',
         // Canonical event names (Vikunja #624 / #667 Decision 5). Wire format:
         //   `compliance:updated`, `compliance:job-started`, etc.
-        // Legacy names (`compliance.checked`, `compliance.job-started`, ...)
-        // are retained for one release to ease rolling upgrades of any ad-hoc
-        // clients not yet moved to the canonical names. New emitters MUST use
-        // the canonical names (no `compliance.` prefix).
         events: [
           // Canonical lifecycle events
           'updated',
@@ -90,15 +86,6 @@ class Phase2WebSocketExtension {
           'templates.requested',
           'history.requested',
           'template.applied',
-          // Legacy — remove in the next major release
-          'compliance.checked',
-          'compliance.job-started',
-          'compliance.job-progress',
-          'compliance.job-completed',
-          'compliance.job-failed',
-          'compliance.application-started',
-          'compliance.application-completed',
-          'compliance.application-failed'
         ]
       },
       {

--- a/docs/COMPLIANCE-API.md
+++ b/docs/COMPLIANCE-API.md
@@ -188,10 +188,10 @@ Trigger compliance check for multiple repositories.
 
 #### Job Status Tracking
 Use WebSocket events to track job progress:
-- `compliance.job-started`: Job execution began
-- `compliance.job-progress`: Progress updates
-- `compliance.job-completed`: Job finished successfully
-- `compliance.job-failed`: Job encountered errors
+- `compliance:job-started`: Job execution began
+- `compliance:job-progress`: Progress updates
+- `compliance:job-completed`: Job finished successfully
+- `compliance:job-failed`: Job encountered errors
 
 ### GET /api/v2/compliance/templates
 List available templates and their requirements.
@@ -341,30 +341,30 @@ Apply templates to repositories with backup and PR creation options.
 
 ## WebSocket Events
 
-The API supports real-time updates via WebSocket connection on the `compliance` channel.
+The API supports real-time updates via WebSocket connection on the `compliance` channel. Wire event names use the `{channel}:{event}` format (Vikunja #624 / #667 Decision 5).
 
 ### Event Types
-- `compliance.checked` - Repository compliance status updated
-- `compliance.job-started` - Compliance check job started
-- `compliance.job-progress` - Job progress update
-- `compliance.job-completed` - Job completed successfully
-- `compliance.job-failed` - Job failed with errors
-- `compliance.application-started` - Template application started
-- `compliance.application-completed` - Template application completed
-- `compliance.application-failed` - Template application failed
-- `status.requested` - Compliance status was requested
-- `repository.checked` - Repository was checked
-- `check.triggered` - Compliance check was triggered
-- `templates.requested` - Template list was requested
-- `history.requested` - Application history was requested
-- `template.applied` - Template was applied
+- `compliance:updated` - Repository compliance status updated
+- `compliance:job-started` - Compliance check job started
+- `compliance:job-progress` - Job progress update
+- `compliance:job-completed` - Job completed successfully
+- `compliance:job-failed` - Job failed with errors
+- `compliance:application-started` - Template application started
+- `compliance:application-completed` - Template application completed
+- `compliance:application-failed` - Template application failed
+- `compliance:status.requested` - Compliance status was requested
+- `compliance:repository.checked` - Repository was checked
+- `compliance:check.triggered` - Compliance check was triggered
+- `compliance:templates.requested` - Template list was requested
+- `compliance:history.requested` - Application history was requested
+- `compliance:template.applied` - Template was applied
 
 ### WebSocket Event Format
 ```json
 {
-  "type": "phase2.event",
+  "type": "compliance:updated",
   "channel": "compliance",
-  "event": "compliance.checked",
+  "event": "updated",
   "data": {
     "repository": "homelab-gitops-auditor",
     "compliant": true,


### PR DESCRIPTION
## Summary

Removes 8 legacy dot-separated event names from the \`compliance\` channel allow-list in \`api/phase2-websocket.js\`. They were retained after the #624/#667 Decision 5 rename to canonical \`{channel}:{event}\` form as a rolling-upgrade safety net. Audit confirms the safety net is unused:

- **Emits:** zero in api/ source (canonical names only)
- **Listeners:** zero in dashboard/src/
- **Tests:** \`compliance-ws.test.js\` actively asserts the legacy names are NOT emitted
- **Scripts:** zero references

Updates \`docs/COMPLIANCE-API.md\` to document canonical wire names (\`compliance:updated\` etc.) and the current envelope shape.

## Test plan

- [x] Baseline: 10 jest suites / 106 tests pass on main
- [x] Post-change: 10 suites / 106 tests still pass
- [x] Coverage thresholds still hold

Closes Vikunja #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)