### PR TITLE
ci: upgrade github/codeql-action v3 → v4

### DIFF
--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v5
       
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: javascript
         config-file: ./.github/codeql/codeql-config.yml
@@ -83,7 +83,7 @@ jobs:
         npm run build
         
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
 
   container-security:
     name: Container Security Scan
@@ -120,7 +120,7 @@ jobs:
         output: 'trivy-results.sarif'
         
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results.sarif'
         

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -55,13 +55,13 @@ jobs:
     
     - name: Run CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: javascript
     
     - name: Perform CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
     
     - name: Scan shell scripts with ShellCheck
       run: |


### PR DESCRIPTION
## Summary

- Bumps all 5 `github/codeql-action` references in our two security workflows from `@v3` to `@v4`.
- Driven by the **June 2, 2026** GitHub-Actions Node 24 default switch — `codeql-action@v3` runs on Node 20 and will break on that date. v4.35.2 (the latest stable, released 2026-04-15) is GA on Node 24.
- Closes Vikunja **#755**.

## Files touched

- `.github/workflows/security-scan.yml` — `init`, `analyze`
- `.github/workflows/security-enhanced.yml` — `init`, `analyze`, `upload-sarif`

## Test plan

- [x] All 5 v3 → v4 swaps verified via grep (`codeql-action.*@v4` × 5, `@v3` × 0)
- [ ] CI green on this PR — both `security-scan.yml` (init+analyze) and `security-enhanced.yml` (init+analyze+upload-sarif) exercise the upgraded actions on a real run
- [ ] No new annotations from CodeQL about Node deprecation

🤖 Generated with [Claude Code](https://claude.com/claude-code)