### PR TITLE
fix(api): clean up jest.config.js validation warnings (#874)

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -94,7 +94,7 @@ module.exports = {
   testTimeout: 30000,
   
   // Module name mapping
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^@config/(.*)$': '<rootDir>/config/$1',
     '^@services/(.*)$': '<rootDir>/services/$1',
@@ -136,8 +136,7 @@ module.exports = {
       setupFilesAfterEnv: [
         '<rootDir>/tests/setup/jest.setup.js',
         '<rootDir>/tests/setup/database.setup.js'
-      ],
-      testTimeout: 60000
+      ]
     },
     {
       displayName: 'WebSocket Tests',
@@ -146,8 +145,7 @@ module.exports = {
       ],
       setupFilesAfterEnv: [
         '<rootDir>/tests/setup/jest.setup.js'
-      ],
-      testTimeout: 30000
+      ]
     }
   ],
   


### PR DESCRIPTION
## Summary
- Fixes one-char typo `moduleNameMapping` → `moduleNameMapper` (api/jest.config.js:97). Path aliases `@services/*`, `@models/*`, `@middleware/*`, etc. were silently failing.
- Removes per-project `testTimeout` from Integration Tests (60000) and WebSocket Tests (30000). In Jest 29, `testTimeout` is a top-level-only option; the per-project values were being discarded as "Unknown option" warnings, so the behavior is already what they're being reduced to (top-level 30s).

Closes the noisy "Validation Warning" output on every Jest run. Does **not** fix the broader CI failures on `main` — those are caused by `uuid@14` ESM `SyntaxError` (bug 2 from #874) and unrelated test-suite issues, both tracked separately.

## Test plan
- [x] `jest tests/routes/compliance.test.js --no-coverage` — confirmed no more `Unknown option` warnings
- [x] `jest --no-coverage` (full sweep) — no new regressions; 5 passing test suites unchanged; 58 still failing for reasons outside this PR's scope (uuid ESM + others)
- [ ] CI `Unit Tests` + `lint-and-test (20.x)` — expected to remain red until uuid ESM fix lands; warning-noise should be gone from logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)