### PR TITLE
security: scrub redflower805 from AdGuard helper scripts

### DIFF
--- a/scripts/audit-ip-consistency.py
+++ b/scripts/audit-ip-consistency.py
@@ -37,7 +37,29 @@ KEA_SECONDARY = "192.168.1.134"
 ADGUARD_HOST = "192.168.1.253"
 ADGUARD_PORT = "80"
 ADGUARD_USER = "root"
-ADGUARD_PASS = "redflower805"
+
+
+def _adguard_password() -> str:
+    """Pull AdGuard root password from Infisical at runtime."""
+    pw = os.environ.get("ADGUARD_PASSWORD")
+    if pw:
+        return pw
+    try:
+        result = subprocess.run(
+            ["infisical-get", "ADGUARD_ROOT_PASSWORD"],
+            capture_output=True, text=True, check=True, timeout=10,
+        )
+        return result.stdout.strip()
+    except (subprocess.SubprocessError, FileNotFoundError) as e:
+        sys.stderr.write(
+            "ERROR: could not retrieve ADGUARD_ROOT_PASSWORD. "
+            "Set ADGUARD_PASSWORD env var or ensure infisical-get is on PATH "
+            f"and the session is valid ({e}).\n"
+        )
+        sys.exit(1)
+
+
+ADGUARD_PASS = _adguard_password()
 
 # Traefik IP (all internal DNS should point here)
 TRAEFIK_IP = "192.168.1.110"

--- a/scripts/retired/sync_npm_to_adguard.py
+++ b/scripts/retired/sync_npm_to_adguard.py
@@ -2,6 +2,8 @@ import argparse
 import base64
 import json
 import os
+import subprocess
+import sys
 
 import requests
 
@@ -10,7 +12,17 @@ NPM_PROXY_PATH = "/opt/npm/data/nginx/proxy_host/"
 ADGUARD_HOST = "192.168.1.253"
 ADGUARD_PORT = "80"
 ADGUARD_USER = "root"
-ADGUARD_PASS = "redflower805"  # 🔒 replace with your actual password
+
+# This script is retired (see scripts/retired/). Kept for reference only.
+# Password is pulled from Infisical at runtime to avoid embedding the literal.
+ADGUARD_PASS = os.environ.get("ADGUARD_PASSWORD") or subprocess.run(
+    ["infisical-get", "ADGUARD_ROOT_PASSWORD"],
+    capture_output=True, text=True, check=False,
+).stdout.strip()
+if not ADGUARD_PASS:
+    sys.stderr.write("ERROR: ADGUARD_PASSWORD not set and infisical-get failed.\n")
+    sys.exit(1)
+
 ADGUARD_TARGET_IP = "192.168.1.95"  # NPM IP for internal rewrites
 
 API_BASE = f"http://{ADGUARD_HOST}:{ADGUARD_PORT}/control"


### PR DESCRIPTION
## Summary

Removes the hardcoded `redflower805` literal from two AdGuard helper scripts. Pulls the password from Infisical (`ADGUARD_ROOT_PASSWORD`) at runtime instead.

## Background

The literal was effectively a no-op until 2026-05-08 — AdGuard at 192.168.1.224 ran with `users: []` and ignored all auth headers. homelab-iac PR #42 enforced auth via a templated `users:` block sourced from Infisical. These two helper scripts still embedded the old shared admin password as a literal.

These scripts target the **replica** (192.168.1.253), which is still auth-less today. But `redflower805` was a shared credential reused for AdGuard root, MQTT broker, WiFi PSK, several SSH passwords — keeping it in tracked code is a continuing audit hygiene problem. Operations bead [#1053](https://vikunja.internal.lakehouse.wtf/tasks/1053) tracks the broader scrub plan.

## Changes

- **`scripts/audit-ip-consistency.py`**: replaces the literal with a `_adguard_password()` helper that prefers `ADGUARD_PASSWORD` env var, falls back to `subprocess.run(['infisical-get', 'ADGUARD_ROOT_PASSWORD'])`, fails fast with a clear error if neither works.
- **`scripts/retired/sync_npm_to_adguard.py`**: same pattern, terser. Script is in `retired/` so kept for reference only.

## Test plan

- [x] Both files parse (`python3 -c "import ast; ast.parse(...)"`)
- [x] `redflower805` literal count is now 0 in both files
- [x] `audit-ip-consistency.py` module-level setup retrieves the new 32-char password via `infisical-get` at runtime
- [ ] Run the full audit script end-to-end after merge (deferred — not blocking, script does only read-only API calls)

## References

- Operations bead [#1053](https://vikunja.internal.lakehouse.wtf/tasks/1053) — Task 2 of monorepo-security-remediation
- Operations bead [#1083](https://vikunja.internal.lakehouse.wtf/tasks/1083) — AdGuard auth gap (CLOSED post-Batch 2B)
- homelab-iac PR [#42](https://github.com/festion/homelab-iac/pull/42) — IaC change that enforces AdGuard auth
- History scrub follows in operations Task 17 (#1068)

🤖 Generated with [Claude Code](https://claude.com/claude-code)