### PR TITLE
security: SHA-pin third-party GitHub Actions + add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot configuration.
+#
+# Tracks third-party GitHub Action SHA pins added in
+# Vikunja #1077 (T26 of the 2026-05-08 monorepo security remediation).
+# When a new release of a pinned action drops, Dependabot opens a PR that
+# updates both the SHA and the trailing `# v<n>` comment.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "npm"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(api)"
+      include: "scope"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Show PowerShell version
         shell: pwsh
@@ -32,7 +32,7 @@ jobs:
           }
 
       - name: Upload audit report as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: daily-audit-report
           path: output/GitRepoReport.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -84,10 +84,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -125,7 +125,7 @@ jobs:
       continue-on-error: true
         
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         files: ./api/coverage/lcov.info,./dashboard/coverage/lcov.info
         flags: unit-tests
@@ -157,10 +157,10 @@ jobs:
           
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -226,10 +226,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -286,7 +286,7 @@ jobs:
         fi
         
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: build-artifacts-${{ github.sha }}
         path: |
@@ -301,10 +301,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload quality report as artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: code-quality-report
           path: output/CodeQualityReport.md

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,10 +21,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -62,7 +62,7 @@ jobs:
         
     - name: Log in to Container Registry
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
         
     - name: Extract metadata for Docker
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -81,7 +81,7 @@ jobs:
         
     - name: Build and push Docker image
       if: github.event_name != 'pull_request'
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         push: true
@@ -99,7 +99,7 @@ jobs:
           .
           
     - name: Upload deployment artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: staging-deployment-${{ github.sha }}
         path: homelab-gitops-auditor-staging-${{ github.sha }}.tar.gz
@@ -209,7 +209,7 @@ jobs:
           
     - name: Notify deployment success
       if: success()
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
       with:
         status: success
         channel: '#deployments'
@@ -226,7 +226,7 @@ jobs:
         
     - name: Notify deployment failure
       if: failure()
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
       with:
         status: failure
         channel: '#deployments'
@@ -248,10 +248,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -308,7 +308,7 @@ jobs:
         EOF
         
     - name: Upload staging report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: staging-report-${{ github.sha }}
         path: staging-report.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Use Node.js 20.x
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -68,7 +68,7 @@ jobs:
         tar -czf homelab-gitops-auditor-${{ github.sha }}.tar.gz -C deploy-staging .
     
     - name: Upload deployment artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: deployment-package-${{ github.sha }}
         path: homelab-gitops-auditor-${{ github.sha }}.tar.gz
@@ -76,7 +76,7 @@ jobs:
     
     - name: Create GitHub release (on tag)
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -109,7 +109,7 @@ jobs:
       TARBALL: homelab-gitops-auditor-${{ github.sha }}.tar.gz
     steps:
       - name: Download deployment artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
 

--- a/.github/workflows/gitops-audit.yml
+++ b/.github/workflows/gitops-audit.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -76,7 +76,7 @@ jobs:
     needs: lint-and-validate
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up required tools
         run: |
@@ -99,7 +99,7 @@ jobs:
           bash scripts/comprehensive_audit.sh --dev
 
       - name: Upload audit results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         if: always()
         with:
           name: audit-report
@@ -111,10 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20'
 
@@ -145,10 +145,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Download audit results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: audit-report
           path: audit-history/

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,10 +33,10 @@ jobs:
           
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -276,7 +276,7 @@ jobs:
         fi
         
     - name: Upload performance artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: performance-results-${{ github.sha }}
         path: |
@@ -309,10 +309,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -368,7 +368,7 @@ jobs:
         fi
         
     - name: Upload Lighthouse results
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: lighthouse-results-${{ github.sha }}
         path: |
@@ -385,7 +385,7 @@ jobs:
     
     steps:
     - name: Download performance artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
       with:
         pattern: '*-results-${{ github.sha }}'
         merge-multiple: true
@@ -436,7 +436,7 @@ jobs:
         echo "- Review error rates during peak load testing" >> PERFORMANCE_SUMMARY.md
         
     - name: Upload performance summary
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: performance-summary-${{ github.sha }}
         path: PERFORMANCE_SUMMARY.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,13 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -177,12 +177,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{ needs.prepare-release.outputs.tag }}
         
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -239,12 +239,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{ needs.prepare-release.outputs.tag }}
         
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -262,7 +262,7 @@ jobs:
         npm run build
         
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -270,7 +270,7 @@ jobs:
         
     - name: Extract metadata for Docker
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -280,7 +280,7 @@ jobs:
           type=raw,value=latest
         
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         push: true
@@ -312,7 +312,7 @@ jobs:
         sha256sum homelab-gitops-auditor-${{ needs.prepare-release.outputs.version }}-source.tar.gz >> checksums.txt
         
     - name: Upload release artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: release-assets-${{ needs.prepare-release.outputs.version }}
         path: |
@@ -328,17 +328,17 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{ needs.prepare-release.outputs.tag }}
         
     - name: Download release artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
       with:
         name: release-assets-${{ needs.prepare-release.outputs.version }}
         
     - name: Create GitHub Release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       id: create_release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -350,7 +350,7 @@ jobs:
         prerelease: ${{ contains(needs.prepare-release.outputs.version, 'alpha') || contains(needs.prepare-release.outputs.version, 'beta') || contains(needs.prepare-release.outputs.version, 'rc') }}
         
     - name: Upload deployment package
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -360,7 +360,7 @@ jobs:
         asset_content_type: application/gzip
         
     - name: Upload source package
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -370,7 +370,7 @@ jobs:
         asset_content_type: application/gzip
         
     - name: Upload checksums
-      uses: actions/upload-release-asset@v1
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -387,7 +387,7 @@ jobs:
     
     steps:
     - name: Trigger staging deployment
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           await github.rest.actions.createWorkflowDispatch({
@@ -404,7 +404,7 @@ jobs:
         sleep 180 # Wait 3 minutes for staging
         
     - name: Trigger production deployment
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           // Only deploy stable releases to production automatically
@@ -431,7 +431,7 @@ jobs:
     
     steps:
     - name: Notify release
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
       with:
         status: success
         channel: '#releases'
@@ -453,7 +453,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         
     - name: Update documentation
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           // Create documentation update issue
@@ -512,7 +512,7 @@ jobs:
         EOF
         
     - name: Upload release report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: release-report-${{ needs.prepare-release.outputs.version }}
         path: RELEASE_REPORT.md

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -39,7 +39,7 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0
         
@@ -91,7 +91,7 @@ jobs:
     
     steps:
     - name: Checkout rollback version
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{ needs.validate-rollback.outputs.rollback_version }}
         
@@ -123,7 +123,7 @@ jobs:
         rm -f prod_key
         
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -141,7 +141,7 @@ jobs:
         npm run build
         
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -305,12 +305,12 @@ jobs:
     
     steps:
     - name: Checkout rollback version
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{ needs.validate-rollback.outputs.rollback_version }}
         
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -414,14 +414,14 @@ jobs:
         EOF
         
     - name: Upload rollback report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: rollback-report-${{ github.event.inputs.environment }}-${{ github.run_id }}
         path: ROLLBACK_REPORT.md
         retention-days: 365
         
     - name: Notify rollback completion
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
       with:
         status: ${{ job.status }}
         channel: '#incidents'
@@ -440,7 +440,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         
     - name: Create incident issue
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           const issue = await github.rest.issues.create({

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -16,7 +16,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0
         
@@ -48,16 +48,16 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
       with:
         languages: javascript
         config-file: ./.github/codeql/codeql-config.yml
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -83,7 +83,7 @@ jobs:
         npm run build
         
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
 
   container-security:
     name: Container Security Scan
@@ -92,7 +92,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Build Docker image
       run: |
@@ -120,7 +120,7 @@ jobs:
         output: 'trivy-results.sarif'
         
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
       with:
         sarif_file: 'trivy-results.sarif'
         
@@ -140,10 +140,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -192,7 +192,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Install ShellCheck
       run: |
@@ -231,10 +231,10 @@ jobs:
           
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20'
         cache: 'npm'
@@ -291,7 +291,7 @@ jobs:
         EOF
         
     - name: Upload security report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: security-report-${{ github.sha }}
         path: security-report.json

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Use Node.js 20.x
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -55,13 +55,13 @@ jobs:
     
     - name: Run CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
       with:
         languages: javascript
     
     - name: Perform CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
     
     - name: Scan shell scripts with ShellCheck
       run: |

--- a/.github/workflows/weekly_audit_email.yml
+++ b/.github/workflows/weekly_audit_email.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: homelab-gitops-auditor
 
@@ -69,7 +69,7 @@ jobs:
           "HTML_BODY<<EOF`n$body`nEOF" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Send audit summary email
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
         with:
           server_address: smtp.gmail.com
           server_port: 587


### PR DESCRIPTION
Closes Vikunja **#1077** (Task 26 of the 2026-05-08 monorepo security remediation).

Replaces all `uses: <action>@v<n>` tag pins in `.github/workflows/` with `uses: <action>@<40-char-sha> # v<n>`. Adds `.github/dependabot.yml` so Dependabot can keep the SHAs current automatically.

## Why

Tag pins like `@v5` are mutable. A malicious or accidentally-broken release can be force-pushed into the v5 tag and silently land in every workflow run. SHA pins are immutable — only Dependabot can rotate them (via PR), giving humans a chance to review.

Especially relevant for this repo's self-hosted runner (CT 2000 on proxmox3) which has SSH-key access to internal infrastructure for the deploy-homelab job. A compromised action could exfil keys / pivot.

## Coverage

100 SHA pins across 13 workflow files. 18 unique `<action>@<tag>` combos resolved via `gh api /repos/<owner>/<repo>/commits/<tag>` on 2026-05-09:

| Action | Tag | SHA prefix |
|---|---|---|
| 8398a7/action-slack | v3 | `77eaa4f1…` |
| actions/checkout | v5 | `93cb6efe…` |
| actions/create-release | v1 | `0cb9c9b6…` |
| actions/download-artifact | v4 | `d3f86a10…` |
| actions/download-artifact | v5 | `634f93cb…` |
| actions/github-script | v8 | `ed597411…` |
| actions/setup-node | v5 | `a0853c24…` |
| actions/setup-python | v6 | `a309ff8b…` |
| actions/upload-artifact | v5 | `330a01c4…` |
| actions/upload-release-asset | v1 | `e8f9f06c…` |
| codecov/codecov-action | v4 | `b9fd7d16…` |
| dawidd6/action-send-mail | v3 | `4226df7d…` |
| docker/build-push-action | v5 | `ca052bb5…` |
| docker/login-action | v3 | `c94ce9fb…` |
| docker/metadata-action | v5 | `c299e40c…` |
| github/codeql-action/{analyze,init,upload-sarif} | v4 | `68bde559…` |

## Dependabot

`.github/dependabot.yml` now configures:
- **github-actions** weekly — Dependabot will open PRs to bump SHAs whenever pinned actions release new versions, updating both the SHA and the `# v<n>` comment in sync.
- **npm/api** weekly — direct deps in `api/package.json` (transitive vulns are still hidden by the gitignored lockfile per #1087, but at least direct deps will surface).

## Verification

- `grep -rE '^\s*-?\s*uses:\s*[^@]+@v[0-9]+\s*$' .github/workflows/` returns zero matches.
- All 14 YAML files parse cleanly via `python3 -c 'import yaml; yaml.safe_load(...)'`.
- Functional behavior is unchanged — each SHA points at the same commit the tag did at lookup time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)