### PR TITLE
fix(homepage): set HOMEPAGE_VAR_INFLUX_USER default to 'administrator'

### DIFF
--- a/api/add-homepage-secrets.js
+++ b/api/add-homepage-secrets.js
@@ -55,7 +55,7 @@ const secrets = {
   'HOMEPAGE_VAR_OMADA_PASS': 'admin',
 
   // InfluxDB Integration
-  'HOMEPAGE_VAR_INFLUX_USER': 'admin',
+  'HOMEPAGE_VAR_INFLUX_USER': 'administrator',
   'HOMEPAGE_VAR_INFLUX_PASS': envOrThrow('HOMEPAGE_VAR_INFLUX_PASS')
 };
 

--- a/scripts/add-homepage-secrets.sh
+++ b/scripts/add-homepage-secrets.sh
@@ -103,7 +103,7 @@ add_secret "HOMEPAGE_VAR_OMADA_USER" "admin"
 add_secret "HOMEPAGE_VAR_OMADA_PASS" "admin"
 
 # InfluxDB
-add_secret "HOMEPAGE_VAR_INFLUX_USER" "admin"
+add_secret "HOMEPAGE_VAR_INFLUX_USER" "administrator"
 add_secret "HOMEPAGE_VAR_INFLUX_PASS" "${HOMEPAGE_VAR_INFLUX_PASS:?HOMEPAGE_VAR_INFLUX_PASS env var required}"
 
 echo ""


### PR DESCRIPTION
## Summary

Tiny string fix: InfluxDB v2.9.0 at 192.168.1.74 (CT 100) has exactly one user named `administrator`, but the committed defaults in `add-homepage-secrets.{js,sh}` had it as `admin`. So any fresh secrets-bootstrap on a clean Infisical would re-introduce the wrong value.

Closes Vikunja **#1091**.

## State of fixes

| Layer | Status |
|---|---|
| Homepage CT 150 `/home/homepage/homepage/.env` | Fixed 2026-05-09 (bundled with #1089) |
| Infisical `HOMEPAGE_VAR_INFLUX_USER` | Fixed 2026-05-10 (`administrator`) |
| **Committed defaults (this PR)** | **Pending merge** |

## Test plan

- [ ] CI green (or fails only on pre-existing #1087 npm vulns)
- [ ] No functional change today — Homepage UI was already authenticating against InfluxDB live with `administrator` since 2026-05-09
- [ ] Future fresh-bootstrap of secrets via `node api/add-homepage-secrets.js` or `bash scripts/add-homepage-secrets.sh` will write the correct value to Infisical

🤖 Generated with [Claude Code](https://claude.com/claude-code)