### PR TITLE
security: pin trivy/snyk/trufflehog actions to tag SHAs

### DIFF
--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -113,7 +113,7 @@ jobs:
         fi
         
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: 'homelab-gitops-auditor:scan'
         format: 'sarif'
@@ -171,15 +171,15 @@ jobs:
       continue-on-error: true
         
     - name: Security scan with Snyk (API)
-      uses: snyk/actions/node@master
+      uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         args: --file=api/package.json --severity-threshold=high
       continue-on-error: true
-        
+
     - name: Security scan with Snyk (Dashboard)
-      uses: snyk/actions/node@master
+      uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -46,7 +46,7 @@ jobs:
       continue-on-error: true
     
     - name: Security scan with Snyk
-      uses: snyk/actions/node@master
+      uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
@@ -71,7 +71,7 @@ jobs:
       continue-on-error: true
     
     - name: Check for secrets in code
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
       with:
         path: ./
         base: main


### PR DESCRIPTION
## Summary

Converts 5 branch-ref action pins to SHA-pinned tagged releases. Companion follow-up to #1077 (Task 26 covered `@v<n>` tag pins; this PR covers `@master`/`@main` branch refs that #1077's regex didn't match).

Closes Vikunja **#1131**.

## Changes

| Action | Before | After |
|---|---|---|
| `aquasecurity/trivy-action` | `@master` | `@ed142fd0… # v0.36.0` |
| `snyk/actions/node` (3 sites) | `@master` | `@9adf32b1… # v1.0.0` |
| `trufflesecurity/trufflehog` | `@main` | `@17456f8c… # v3.95.2` |

Tag SHAs resolved via `gh api repos/<owner>/<repo>/commits/<tag>` on 2026-05-10. `dependabot.yml` (added in #1077) will now surface PRs to bump these as new tagged releases drop.

## Why

Branch refs are mutable — every push to upstream `master` / `main` takes effect immediately, no version semantics to anchor. SHA pins are immutable; only Dependabot can rotate them via PR.

## Test plan

- [ ] CI green (or fails only on pre-existing #1087 npm vulns, same as #122/#135)
- [ ] All 13 workflow YAML files still parse cleanly (verified locally via `yaml.safe_load`)
- [ ] Trivy / Snyk / Trufflehog scans still run successfully — functional behavior unchanged since each tag SHA is the same commit those branches pointed at near tag-cut time

## Out of scope

- `ghcr.io/trufflesecurity/trufflehog:latest` Docker image ref on `security-enhanced.yml:41` — separate ecosystem, not a GH action; flagged for a future PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)