### PR TITLE
feat(homepage): add ttyd Web Terminal tile

### DIFF
--- a/infrastructure/homepage/services.yaml
+++ b/infrastructure/homepage/services.yaml
@@ -250,3 +250,8 @@
         icon: mdi-pulse
         href: https://pulse.internal.lakehouse.wtf
         description: Status Page
+
+    - Web Terminal:
+        icon: mdi-console
+        href: https://ttyd.internal.lakehouse.wtf
+        description: Browser-based terminal (ttyd)


### PR DESCRIPTION
## Summary
- Adds a Web Terminal tile under the DevOps category pointing at https://ttyd.internal.lakehouse.wtf.
- Companion to homelab-iac #74 (Traefik route) and homelab-iac #75 (AdGuard rewrite).

## Test plan
- [x] YAML lint passes
- [ ] After merge: SCP services.yaml to 192.168.1.45 + restart homepage.service (per infrastructure/homepage/README.md)
- [ ] Tile visible at https://homepage.internal.lakehouse.wtf