### PR TITLE
fix(deps): bump axios to ^1.16.0 to clear CVE chain

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -12,7 +12,7 @@
         "@heroicons/react": "^2.2.0",
         "@tanstack/react-query": "^5.82.0",
         "@types/js-yaml": "^4.0.9",
-        "axios": "^1.13.5",
+        "axios": "^1.16.0",
         "cronstrue": "^3.0.0",
         "date-fns": "^4.1.0",
         "js-yaml": "^4.1.1",
@@ -4049,14 +4049,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -4808,7 +4834,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7531,8 +7556,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,7 +18,7 @@
     "@heroicons/react": "^2.2.0",
     "@tanstack/react-query": "^5.82.0",
     "@types/js-yaml": "^4.0.9",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "cronstrue": "^3.0.0",
     "date-fns": "^4.1.0",
     "js-yaml": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@modelcontextprotocol/server-github": "^2025.4.8",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.16.0",
         "chokidar": "^3.5.3",
         "concurrently": "^9.1.0",
         "dotenv": "^16.3.1",
@@ -1900,14 +1900,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@modelcontextprotocol/server-github": "^2025.4.8",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "chokidar": "^3.5.3",
     "concurrently": "^9.1.0",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
## Summary
Resolves the axios 1.0.0–1.15.1 ~14-advisory chain (prototype pollution, SSRF, CRLF, header injection) that has been failing CI's Code Quality / Dependency / Security jobs since at least PR #135 (Vikunja [#1272](https://vikunja.internal.lakehouse.wtf/tasks/1272)).

## Before
| Consumer | axios version | Vulnerable? |
|---|---|---|
| Top-level (`package.json`) | `^1.13.5` (installed 1.15.0) | yes |
| `dashboard/package.json` | `^1.13.5` (installed 1.15.0) | yes |
| `api/package.json` | `^1.16.0` (installed 1.16.0) | no (already fixed) |

## After
| Consumer | axios version | Vulnerable? |
|---|---|---|
| Top-level | `^1.16.0` → 1.16.1 | no |
| `dashboard/` | `^1.16.0` → 1.16.1 | no |
| `api/` | unchanged | no |

`npm audit` in `dashboard/` reports **0 vulnerabilities**. Top-level still has 4 unrelated (fast-uri, ip-address) — out of scope for this PR.

## Out of scope
- 4 remaining top-level vulns (fast-uri / ip-address chain) — will track separately if not already tracked
- `wikijs-*` subdirs (decommissioned, extraneous axios installs)

## Test plan
- [ ] `IaC Validate` / CI checks pass green (specifically the three that have been failing: Code Quality Checks, Dependency Vulnerability Check, Security and Dependencies Check)
- [ ] `cd dashboard && npm audit` reports 0 vulnerabilities
- [ ] `cd dashboard && npm test` and `cd api && npm test` pass (per Gemini suggestion)
- [ ] Production deploy after merge: dashboard renders, API responds — no axios import errors

Closes [Vikunja #1272](https://vikunja.internal.lakehouse.wtf/tasks/1272).

🤖 Generated with [Claude Code](https://claude.com/claude-code)