### PR TITLE
feat(api): add /health liveness probe (un-rate-limited) for Traefik

### DIFF
--- a/api/createApp.js
+++ b/api/createApp.js
@@ -97,6 +97,15 @@ function createApp({
     }, wikiRoutes);
   }
 
+  // Liveness probe for upstream proxies (Traefik). Bypasses rate-limit and
+  // any data-loading — must stay cheap, always-200, and never tied to a
+  // rate-limited path. Vikunja #1309: previously Traefik probed /audit
+  // every 30s, which tripped auditRateLimit and cascaded into 503 for real
+  // user traffic. Keep this route ordered BEFORE /audit so it's not shadowed.
+  app.get('/health', (req, res) => {
+    res.status(200).json({ status: 'ok' });
+  });
+
   // Load latest audit report.
   app.get('/audit', auditRateLimit, (req, res) => {
     try {

--- a/api/tests/routes/rate-limiting.test.js
+++ b/api/tests/routes/rate-limiting.test.js
@@ -78,4 +78,16 @@ describe('Rate limiting on auth-gated routes (#669)', () => {
     });
   });
 
+  // Vikunja #1309: /health must NOT carry rate-limit middleware. Traefik
+  // probes this endpoint every 30s from multiple upstreams; if it were
+  // rate-limited, the resulting 429s would cascade Traefik into marking the
+  // backend unhealthy and returning 503 to real users.
+  describe('/health (liveness probe for upstream proxies)', () => {
+    it('GET /health exists and is NOT rate-limited', () => {
+      const handlers = getRouteHandlers(app, 'get', '/health');
+      expect(handlers.length).toBeGreaterThan(0);
+      expect(handlers.some(isRateLimitMiddleware)).toBe(false);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary
First half of the fix for Vikunja [#1309](https://vikunja.internal.lakehouse.wtf/tasks/1309) — Traefik's prod healthcheck currently polls `/audit` which is rate-limited, triggering 429 cascades that mark the backend unhealthy and return 503 to real users.

## What this changes
- **`api/createApp.js`**: New `GET /health` route registered before `/audit`, returns `{ status: 'ok' }` 200. **Not** wrapped in `auditRateLimit`.
- **`api/tests/routes/rate-limiting.test.js`**: New test asserts `/health` does NOT carry rate-limit middleware (inverse of the #669 contract — protects against accidental re-wrapping).

## Why a dedicated `/health` and not `path: /`
The API does not serve a useful root response (currently 404). Adding a tiny dedicated endpoint matches the pattern already in `services.yml` for `influx-service` which uses `/ping`.

## What does NOT land in this PR
The Traefik side — switching `healthCheck.path` from `/audit` → `/health` — is a separate PR in `homelab-iac` that's gated on this one being deployed first. Otherwise Traefik would 404 on `/health` and *still* mark the backend unhealthy. Order: this PR merges + deploys → homelab-iac PR merges + reconcile-applies → verify HTTPS `gitops.internal.lakehouse.wtf/audit` returns 200 reliably.

## Test plan
- [x] `cd api && npx jest tests/routes/rate-limiting.test.js` — 15/15 pass (new test included)
- [ ] CI green
- [ ] After merge + deploy, `curl http://192.168.1.136:3070/health` returns `{"status":"ok"}` HTTP 200

Part 1 of 2 for Vikunja #1309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)