### PR TITLE
decom: remove CT 125 (zwave-js-ui) Traefik mirror + monitoring + homepage + Node-RED

### DIFF
--- a/infrastructure/homepage/services.yaml
+++ b/infrastructure/homepage/services.yaml
@@ -182,11 +182,6 @@
           type: zigbee2mqtt
           url: http://192.168.1.228:8099
 
-    - Z-Wave JS UI:
-        icon: mdi-z-wave
-        href: https://zwave-js-ui.internal.lakehouse.wtf
-        description: Z-Wave Device Management
-
     - MQTT Broker:
         icon: mqtt.png
         href: http://192.168.1.85

--- a/infrastructure/traefik/config/dynamic/routers.yml
+++ b/infrastructure/traefik/config/dynamic/routers.yml
@@ -276,28 +276,6 @@ http:
         certResolver: cloudflare
         domains:
         - main: '*.internal.lakehouse.wtf'
-    zwave-js-ui-router:
-      rule: Host(`zwave-js-ui.internal.lakehouse.wtf`)
-      service: zwave-js-ui-service
-      entryPoints:
-      - websecure
-      middlewares:
-      - secure-headers
-      tls:
-        certResolver: cloudflare
-        domains:
-        - main: '*.internal.lakehouse.wtf'
-    zwave-router:
-      rule: Host(`zwave.internal.lakehouse.wtf`)
-      service: zwave-js-ui-service
-      entryPoints:
-      - websecure
-      middlewares:
-      - secure-headers
-      tls:
-        certResolver: cloudflare
-        domains:
-        - main: '*.internal.lakehouse.wtf'
     truenas-router:
       rule: Host(`truenas.internal.lakehouse.wtf`)
       service: truenas-service

--- a/infrastructure/traefik/config/dynamic/services.yml
+++ b/infrastructure/traefik/config/dynamic/services.yml
@@ -143,15 +143,6 @@ http:
           path: /
           interval: 30s
           timeout: 5s
-    zwave-js-ui-service:
-      loadBalancer:
-        serversTransport: insecure-transport
-        servers:
-        - url: https://192.168.1.141:8091
-        healthCheck:
-          path: /
-          interval: 30s
-          timeout: 5s
     truenas-service:
       loadBalancer:
         serversTransport: insecure-transport

--- a/infrastructure/traefik/monitoring/prometheus-rules.yml
+++ b/infrastructure/traefik/monitoring/prometheus-rules.yml
@@ -245,12 +245,12 @@ groups:
     rules:
       - alert: SmartHomeServiceDegraded
         expr: |
-          traefik_service_server_up{service=~"homeassistant|z2m|zwave-js-ui"} == 0
+          traefik_service_server_up{service=~"homeassistant|z2m"} == 0
           or
           (
-            sum(rate(traefik_service_requests_total{service=~"homeassistant|z2m|zwave-js-ui",code=~"5.."}[5m])) by (service)
+            sum(rate(traefik_service_requests_total{service=~"homeassistant|z2m",code=~"5.."}[5m])) by (service)
             /
-            sum(rate(traefik_service_requests_total{service=~"homeassistant|z2m|zwave-js-ui"}[5m])) by (service)
+            sum(rate(traefik_service_requests_total{service=~"homeassistant|z2m"}[5m])) by (service)
           ) * 100 > 5
         for: 2m
         labels:

--- a/infrastructure/traefik/monitoring/prometheus-traefik.yml
+++ b/infrastructure/traefik/monitoring/prometheus-traefik.yml
@@ -49,7 +49,7 @@ scrape_configs:
 
       # Add service_type label based on service name
       - source_labels: [service]
-        regex: '(homeassistant|z2m|zwave-js-ui)'
+        regex: '(homeassistant|z2m)'
         target_label: service_type
         replacement: 'smart-home'
 


### PR DESCRIPTION
## Context

Companion PR to [homelab-iac#91](https://github.com/festion/homelab-iac/pull/91). Completes the CT 125 decommission cleanup on the GitOps side — mirrors the Traefik config that was removed from the ansible role, scrubs monitoring config, and removes the homepage tile.

Plan doc: `home-assistant-config/docs/plans/2026-05-02-zwave-js-native-migration-plan.md` — **Task 10** (post-migration cleanup, 2-week window).

## Changes

- `infrastructure/traefik/config/dynamic/routers.yml` — removed `zwave-js-ui-router` and `zwave-router`
- `infrastructure/traefik/config/dynamic/services.yml` — removed `zwave-js-ui-service` (pointed at `192.168.1.141:8091`)
- `infrastructure/homepage/services.yaml` — removed **Z-Wave JS UI** tile (`zwave-js-ui.internal.lakehouse.wtf`)
- `infrastructure/traefik/monitoring/prometheus-traefik.yml` — removed `zwave-js-ui` from the `smart-home` service_type regex (now `(homeassistant|z2m)`)
- `infrastructure/traefik/monitoring/prometheus-rules.yml` — removed `|zwave-js-ui` from all three service selector regexes in `SmartHomeServiceDegraded`

## ⚠️ Partial — Node-RED flow not found

`infrastructure/node-red/auto-remediation-flow.json` **does not exist** in this repository. The `node-red` directory is absent from `infrastructure/`. The `serviceMap` entry for `zwave` (CT 125) still needs to be removed manually or from wherever the Node-RED flows are actually stored/deployed.

## Notes

- Merge this PR **after** homelab-iac#91 is merged and Terraform state has been cleaned up
- After merging, reload Traefik on **proxmox** and **proxmox3** to pick up the updated GitOps config
- The 192.168.1.32 DHCP reservation in Kea config is a separate follow-up (not in scope here)

> **Do not merge without completing the homelab-iac pre-merge checklist. Do not auto-merge.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01DajtedZNZq58A2Ncc17cf8)_