### PR TITLE
ci(deploy): serialize deploys with a concurrency group (HA parity)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,16 @@ on:
         - production
         - staging
 
+# Serialize deploys: the deploy-homelab job ships to a shared staging dir
+# (/opt/gitops-new) on the prod host, so two overlapping runs corrupt each
+# other's tree mid-swap (caused a live outage 2026-07-02 when a push deploy
+# and a workflow_dispatch raced). Never cancel an in-flight deploy — let it
+# finish and swap atomically before the next one starts. Mirrors the
+# home-assistant-config deploy's concurrency group.
+concurrency:
+  group: deploy-to-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds `concurrency: {group: deploy-to-production, cancel-in-progress: false}`, matching the `home-assistant-config` deploy. Completes the HA-pattern parity from #166.

## Why
`deploy-homelab` ships to a **shared** `/opt/gitops-new` staging dir on the prod host. Two overlapping runs clobber each other mid-swap. This happened 2026-07-02 — the merge-push deploy of #166 raced a `workflow_dispatch` verify deploy and crash-looped the service (`sqlite3 ERR_DLOPEN_FAILED` from a half-rebuilt tree). Prod was restored by hand; this prevents recurrence.

`cancel-in-progress: false` because a deploy mid-swap must never be interrupted.

## Verification
- `deploy.yml` parses (yaml OK).
- Post-merge: the single push deploy runs alone (no race) and should go fully green incl. smoke test — the clean end-to-end validation of #166's SSH change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)