### PR TITLE
ci(deploy): skip prod redeploy on docs-only pushes (paths-ignore)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
+    # Skip the full build + prod redeploy for documentation-only pushes. The
+    # deploy package (see the `deploy` job) copies api/dashboard/config/scripts
+    # only — never .claude/ or docs — so a docs change ships an identical
+    # artifact. workflow_dispatch is unaffected (it ignores paths filters), so a
+    # manual deploy is always available.
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - 'docs/**'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Docs/learnings-only pushes to main triggered a full build + prod redeploy (seen with the #168 merge). The deploy package copies `api/dashboard/config/scripts` only — never `.claude/` or docs — so a docs change ships an identical artifact.

Adds `paths-ignore` (`**/*.md`, `.claude/**`, `docs/**`, `.gitignore`) to the `push` trigger only. `workflow_dispatch` ignores paths filters, so a manual deploy is always available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)