### PR TITLE
ci: bump artifact actions to Node-24 runtimes (#2053)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,7 +32,7 @@ jobs:
           }
 
       - name: Upload audit report as artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: daily-audit-report
           path: output/GitRepoReport.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
         fi
         
     - name: Upload build artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: build-artifacts-${{ github.sha }}
         path: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload quality report as artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: code-quality-report
           path: output/CodeQualityReport.md

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -99,7 +99,7 @@ jobs:
           .
           
     - name: Upload deployment artifact
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: staging-deployment-${{ github.sha }}
         path: homelab-gitops-auditor-staging-${{ github.sha }}.tar.gz
@@ -308,7 +308,7 @@ jobs:
         EOF
         
     - name: Upload staging report
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: staging-report-${{ github.sha }}
         path: staging-report.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
         tar -czf homelab-gitops-auditor-${{ github.sha }}.tar.gz -C deploy-staging .
     
     - name: Upload deployment artifact
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: deployment-package-${{ github.sha }}
         path: homelab-gitops-auditor-${{ github.sha }}.tar.gz
@@ -134,7 +134,7 @@ jobs:
       TARBALL: homelab-gitops-auditor-${{ github.sha }}.tar.gz
     steps:
       - name: Download deployment artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ env.ARTIFACT_NAME }}
 

--- a/.github/workflows/gitops-audit.yml
+++ b/.github/workflows/gitops-audit.yml
@@ -99,7 +99,7 @@ jobs:
           bash scripts/comprehensive_audit.sh --dev
 
       - name: Upload audit results
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: audit-report
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download audit results
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: audit-report
           path: audit-history/

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -276,7 +276,7 @@ jobs:
         fi
         
     - name: Upload performance artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: performance-results-${{ github.sha }}
         path: |
@@ -368,7 +368,7 @@ jobs:
         fi
         
     - name: Upload Lighthouse results
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: lighthouse-results-${{ github.sha }}
         path: |
@@ -385,7 +385,7 @@ jobs:
     
     steps:
     - name: Download performance artifacts
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         pattern: '*-results-${{ github.sha }}'
         merge-multiple: true
@@ -436,7 +436,7 @@ jobs:
         echo "- Review error rates during peak load testing" >> PERFORMANCE_SUMMARY.md
         
     - name: Upload performance summary
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: performance-summary-${{ github.sha }}
         path: PERFORMANCE_SUMMARY.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,7 +312,7 @@ jobs:
         sha256sum homelab-gitops-auditor-${{ needs.prepare-release.outputs.version }}-source.tar.gz >> checksums.txt
         
     - name: Upload release artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: release-assets-${{ needs.prepare-release.outputs.version }}
         path: |
@@ -333,7 +333,7 @@ jobs:
         ref: ${{ needs.prepare-release.outputs.tag }}
         
     - name: Download release artifacts
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: release-assets-${{ needs.prepare-release.outputs.version }}
         
@@ -512,7 +512,7 @@ jobs:
         EOF
         
     - name: Upload release report
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: release-report-${{ needs.prepare-release.outputs.version }}
         path: RELEASE_REPORT.md

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -414,7 +414,7 @@ jobs:
         EOF
         
     - name: Upload rollback report
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: rollback-report-${{ github.event.inputs.environment }}-${{ github.run_id }}
         path: ROLLBACK_REPORT.md

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -291,7 +291,7 @@ jobs:
         EOF
         
     - name: Upload security report
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: security-report-${{ github.sha }}
         path: security-report.json


### PR DESCRIPTION
## What
Bump the pinned `actions/upload-artifact` and `actions/download-artifact` versions across all workflows to their lowest majors that default to the **Node 24** runtime, clearing the `Node.js 20 is deprecated` warnings observed in the `deploy-homelab` job (run 28811813809, PR #170).

| action | before (node20) | after (node24) |
|---|---|---|
| `upload-artifact` | `330a01c` `# v5` | `b7c566a` `# v6.0.0` |
| `download-artifact` | `d3f86a1` `# v4` / `634f93c` `# v5` | `37930b1` `# v7.0.0` |

18 `uses:` across 9 workflow files.

## Why these versions
Verified each candidate's `runs.using` from its `action.yml`:
- `upload-artifact` v5 = **node20**; v6.0.0 = **node24** (pure runtime bump, no behavior change).
- `download-artifact` v4/v5/v6 = **node20**; v7.0.0 = **node24** (pure runtime bump).
- Deliberately **stopped before `download-artifact` v8**, which changes the default hash-mismatch behavior to **error** (breaking).

## Runner compatibility
Both v6/v7 require Actions Runner ≥ `2.327.1`. The self-hosted runners (`github-runner`, `github-runner-2`) report `2.335.1` — floor satisfied. The GitHub-hosted `deploy` job (`ubuntu-latest`) is always current.

## Verification
- No node20 artifact SHAs remain (grep clean).
- All workflows parse (`yaml.safe_load`).
- Other official actions already on node24: `checkout@v6.0.2`, `setup-node@v5`, `setup-python@v6`, `github-script@v9`.

## Not in scope
Archived third-party actions `actions/create-release` and `actions/upload-release-asset` (in `release.yml`) still run on old node — they can't be *bumped*, only *replaced* (e.g. `softprops/action-gh-release`). Tracked separately.

Closes #2053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)