### PR TITLE
ci: replace archived create-release/upload-release-asset with gh CLI (#2054)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,14 +96,11 @@ jobs:
     
     - name: Create GitHub release (on tag)
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      # gh is preinstalled on ubuntu-latest; replaces archived actions/create-release.
+      run: gh release create "$TAG" --title "Release $TAG" --notes "" --verify-tag
 
   deploy-homelab:
     # Runs on the self-hosted runner inside the homelab network so it can

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,46 +338,26 @@ jobs:
         name: release-assets-${{ needs.prepare-release.outputs.version }}
         
     - name: Create GitHub Release
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
-      id: create_release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ needs.prepare-release.outputs.tag }}
-        release_name: Release ${{ needs.prepare-release.outputs.tag }}
-        body: ${{ needs.prepare-release.outputs.changelog }}
-        draft: false
-        prerelease: ${{ contains(needs.prepare-release.outputs.version, 'alpha') || contains(needs.prepare-release.outputs.version, 'beta') || contains(needs.prepare-release.outputs.version, 'rc') }}
-        
-    - name: Upload deployment package
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./homelab-gitops-auditor-${{ needs.prepare-release.outputs.version }}.tar.gz
-        asset_name: homelab-gitops-auditor-${{ needs.prepare-release.outputs.version }}.tar.gz
-        asset_content_type: application/gzip
-        
-    - name: Upload source package
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./homelab-gitops-auditor-${{ needs.prepare-release.outputs.version }}-source.tar.gz
-        asset_name: homelab-gitops-auditor-${{ needs.prepare-release.outputs.version }}-source.tar.gz
-        asset_content_type: application/gzip
-        
-    - name: Upload checksums
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./checksums.txt
-        asset_name: checksums.txt
-        asset_content_type: text/plain
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.prepare-release.outputs.tag }}
+        VERSION: ${{ needs.prepare-release.outputs.version }}
+        CHANGELOG: ${{ needs.prepare-release.outputs.changelog }}
+        PRERELEASE: ${{ contains(needs.prepare-release.outputs.version, 'alpha') || contains(needs.prepare-release.outputs.version, 'beta') || contains(needs.prepare-release.outputs.version, 'rc') }}
+      run: |
+        # Create the release and upload all assets in a single gh call (gh is
+        # preinstalled on ubuntu-latest). Replaces archived actions/create-release
+        # + actions/upload-release-asset, which have no maintained Node-24 release.
+        args=(
+          "$TAG"
+          "homelab-gitops-auditor-${VERSION}.tar.gz"
+          "homelab-gitops-auditor-${VERSION}-source.tar.gz"
+          "checksums.txt"
+          --title "Release ${TAG}"
+          --notes "$CHANGELOG"
+        )
+        if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
+        gh release create "${args[@]}"
 
   deploy-release:
     name: Deploy Release


### PR DESCRIPTION
## What
Removes the last GitHub-**archived** actions from the workflows:
- `actions/create-release@v1`
- `actions/upload-release-asset@v1`

Both are used in `release.yml` (create-release job) and `deploy.yml` (on-tag release step). They're replaced with `gh release create` run-steps.

## Why `gh` instead of a maintained action
These two actions were archived by GitHub and have **no Node-24 release** — they can only be *replaced*, not bumped (the sibling problem to #2053). I checked the usual drop-in, `softprops/action-gh-release@v2`, and its `action.yml` still declares `runs.using: node20` — so migrating there would trade the "archived" problem for the same Node-20 deprecation warning #2053 just cleared.

`gh` is preinstalled on `ubuntu-latest`, so a `run:` step has **no Node runtime at all** (no deprecation warning, ever) and **no third-party/supply-chain dependency**.

## Changes
**`release.yml` — create-release job:** the 4 steps (1 create + 3 `upload-release-asset`) collapse into a single `gh release create` that creates the release and uploads all three assets with their existing filenames, preserving the prerelease conditional. Verified no downstream job consumed the old `steps.create_release.outputs.upload_url` (only the 3 upload steps in the same job did).

**`deploy.yml` — "Create GitHub release (on tag)":** same swap. Also corrects the tag: the old step passed `github.ref` (`refs/tags/vX`) as `tag_name`; the `gh` version uses `github.ref_name` (`vX`) with `--verify-tag`.

Net: `-46 / +23` lines across the two files.

## Verification
- Both workflows parse (`yaml.safe_load`).
- `grep` confirms zero `create-release` / `upload-release-asset` references remain in `.github/workflows/`.
- Runtime path (an actual release) only exercises on a tag/release event — not triggered by this PR; flagged below.

Closes #2054. Follow-up to #2053 (#171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)