### PR TITLE
fix(audit): presence-only mode when no local clone mirror (kill /mnt/c/GIT false-red)

### DIFF
--- a/config/settings.conf
+++ b/config/settings.conf
@@ -8,7 +8,13 @@ PRODUCTION_SERVER_PORT="22"
 PRODUCTION_BASE_PATH="/opt/gitops"
 
 # Local Development Configuration
-LOCAL_GIT_ROOT="/mnt/c/GIT"
+# LOCAL_GIT_ROOT points at a local clone mirror for the comprehensive audit's
+# dirty/mismatch checks. It is dev-only and OPT-IN: leave empty on hosts that
+# have no local clone tree (e.g. the production dashboard CT, which runs a
+# presence-only sync) — the comprehensive audit then degrades to presence-only
+# instead of false-reporting every repo as "missing". Set it (e.g. to your
+# ~/git dir) only where a real mirror exists.
+LOCAL_GIT_ROOT=""
 DEVELOPMENT_API_PORT="3070"
 DEVELOPMENT_DASHBOARD_PORT="5173"
 

--- a/scripts/comprehensive_audit.sh
+++ b/scripts/comprehensive_audit.sh
@@ -160,6 +160,24 @@ else
   echo "⚠️  Local Git root directory not found: $LOCAL_GIT_ROOT"
 fi
 
+# Determine whether there is a real local clone mirror to audit against.
+# Hosts that don't maintain a local clone tree (e.g. the production dashboard
+# CT, which only runs a presence-only nightly sync) may have LOCAL_GIT_ROOT
+# absent, empty, or holding stray non-git dirs. In that case treat every GitHub
+# repo as "present" rather than "missing locally" — otherwise the audit
+# false-reports health=red for every repo. The local-scan checks (dirty /
+# mismatch / missing) only make sense when a mirror actually exists.
+local_git_count=0
+for _r in "${!local_repo_status[@]}"; do
+  [ "${local_repo_status[$_r]}" != "not_git" ] && local_git_count=$((local_git_count + 1))
+done
+
+LOCAL_SCAN_ACTIVE=1
+if [ ! -d "$LOCAL_GIT_ROOT" ] || [ "$local_git_count" -eq 0 ]; then
+  LOCAL_SCAN_ACTIVE=0
+  echo "ℹ️  No local git mirror found under '${LOCAL_GIT_ROOT}' — running in presence-only mode (local dirty/mismatch/missing checks skipped)."
+fi
+
 ### ANALYZE MISMATCHES ###
 declare -A github_repos
 for repo in "${remote_repos[@]}"; do
@@ -178,6 +196,12 @@ echo "🔍 Analyzing repository mismatches..."
 
 # Check each GitHub repo
 for repo in "${remote_repos[@]}"; do
+  if [ "$LOCAL_SCAN_ACTIVE" -eq 0 ]; then
+    # Presence-only mode: no local mirror to compare against, so the repo is
+    # simply present on GitHub (not "missing locally").
+    clean_repos+=("$repo")
+    continue
+  fi
   if [[ -v local_repos["$repo"] ]]; then
     # Repo exists locally, check status
     status="${local_repo_status[$repo]}"
@@ -246,6 +270,7 @@ echo "  Health Status: $health_status"
   echo "  \"timestamp\": \"${TIMESTAMP}\","
   echo "  \"health_status\": \"${health_status}\","
   echo "  \"local_git_root\": \"${LOCAL_GIT_ROOT}\","
+  echo "  \"local_scan_active\": $([ "$LOCAL_SCAN_ACTIVE" -eq 1 ] && echo true || echo false),"
   echo "  \"github_user\": \"${GITHUB_USER}\","
   echo "  \"summary\": {"
   echo "    \"total\": ${total_repos},"
@@ -323,8 +348,8 @@ echo "  Health Status: $health_status"
   # Clean repositories
   for repo in "${clean_repos[@]}"; do
     [[ $first -eq 0 ]] && echo ","
-    repo_path="${local_repos[$repo]}"
-    file_status="${local_repo_files[$repo]}"
+    repo_path="${local_repos[$repo]:-}"
+    file_status="${local_repo_files[$repo]:-unknown}"
     echo "    {"
     echo "      \"name\": \"$repo\","
     echo "      \"status\": \"clean\","

--- a/scripts/config/config-loader.sh
+++ b/scripts/config/config-loader.sh
@@ -17,7 +17,11 @@ load_config() {
     PRODUCTION_SERVER_PORT="${PRODUCTION_SERVER_PORT:-22}"
     PRODUCTION_BASE_PATH="${PRODUCTION_BASE_PATH:-/opt/gitops}"
     
-    LOCAL_GIT_ROOT="${LOCAL_GIT_ROOT:-/mnt/c/GIT}"
+    # Opt-in local clone mirror for the comprehensive audit. Default empty:
+    # hosts without a local clone tree (e.g. the prod dashboard CT) run the
+    # comprehensive audit in presence-only mode. Override in the user/settings
+    # config where a real mirror exists.
+    LOCAL_GIT_ROOT="${LOCAL_GIT_ROOT:-}"
     DEVELOPMENT_API_PORT="${DEVELOPMENT_API_PORT:-3070}"
     DEVELOPMENT_DASHBOARD_PORT="${DEVELOPMENT_DASHBOARD_PORT:-5173}"
     


### PR DESCRIPTION
## Problem
`comprehensive_audit.sh` reported **health=red / all repos "MISSING LOCALLY"** whenever `LOCAL_GIT_ROOT` held no real git clones. On the prod dashboard CT (CT 123) the root defaulted to a leftover WSL path `/mnt/c/GIT` (a dir with only a stray non-git dir), so clicking **Run Comprehensive Audit** produced an all-red report and clobbered the green presence-report on the live dashboard. Surfaced while testing the audit this session (Vikunja #2078).

## Root cause
The `/mnt/c/GIT` value came from the **hardcoded default in `scripts/config/config-loader.sh`** (`${LOCAL_GIT_ROOT:-/mnt/c/GIT}`). CT 123 maintains no local clone mirror — its nightly job is presence-only (`sync_github_repos.sh`). The comprehensive audit's local-scan model simply doesn't apply there, but it still red-flagged every repo as missing.

## Fix
- **`comprehensive_audit.sh`**: detect whether a real mirror exists (≥1 git repo under `LOCAL_GIT_ROOT`). If not → **presence-only mode**: repos are "present", not "missing"; health stays green. Adds a `local_scan_active` flag to the JSON. Clean-repo JSON fields guarded with `:-` defaults (set -u safe).
- **`config-loader.sh`**: drop the hardcoded `/mnt/c/GIT` default → `LOCAL_GIT_ROOT` is opt-in (empty ⇒ presence-only).
- **`config/settings.conf`**: same, with an explanatory comment.

## Verification
- **Presence-only** (no mirror, CT 123 case): `health=green`, `local_scan_active=false`, 28 clean, 0 missing ✅
- **Active** (real 1-repo mirror): the one repo clean, other 27 genuinely missing → `health=red`, `local_scan_active=true` ✅ (real audit logic intact)
- `bash -n` + shellcheck clean on changed scripts (no new warnings). CI `gitops-audit.yml` clones 2 repos into `/tmp/git-simulation` → stays in active mode, unaffected.

## Note (out of scope)
Pre-existing latent bug: `config-loader.sh` reads `scripts/config/settings.conf` (project_root=`scripts`) but the version-controlled settings file is top-level `config/settings.conf` — so that file is never actually loaded by the audit (defaults always win). This fix is correct regardless; flagging for a follow-up.

Fixes #2078 (Vikunja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)