### PR TITLE
fix(config): resolve config-loader project_root to repo root (read top-level config/)

### DIFF
--- a/scripts/config/config-loader.sh
+++ b/scripts/config/config-loader.sh
@@ -7,7 +7,10 @@
 # Function to load configuration from file
 load_config() {
     local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local project_root="$(dirname "$script_dir")"
+    # config-loader.sh lives in scripts/config/, so the repo root is two levels
+    # up — the canonical config/ dir is at the repo root (matches api/config-loader.js
+    # and config-manager.sh's documented config/settings.conf), NOT scripts/config/.
+    local project_root="$(dirname "$(dirname "$script_dir")")"
     local config_file="${project_root}/config/settings.conf"
     local user_config_file="${project_root}/config/settings.local.conf"
     
@@ -90,7 +93,10 @@ show_config() {
 # Function to create user config template
 create_user_config() {
     local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local project_root="$(dirname "$script_dir")"
+    # config-loader.sh lives in scripts/config/, so the repo root is two levels
+    # up — the canonical config/ dir is at the repo root (matches api/config-loader.js
+    # and config-manager.sh's documented config/settings.conf), NOT scripts/config/.
+    local project_root="$(dirname "$(dirname "$script_dir")")"
     local user_config_file="${project_root}/config/settings.local.conf"
     
     if [ -f "$user_config_file" ]; then
@@ -223,7 +229,10 @@ configure_interactive() {
     
     # Create user config file with new settings
     local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local project_root="$(dirname "$script_dir")"
+    # config-loader.sh lives in scripts/config/, so the repo root is two levels
+    # up — the canonical config/ dir is at the repo root (matches api/config-loader.js
+    # and config-manager.sh's documented config/settings.conf), NOT scripts/config/.
+    local project_root="$(dirname "$(dirname "$script_dir")")"
     local user_config_file="${project_root}/config/settings.local.conf"
     
     cat > "$user_config_file" << EOF

--- a/scripts/config/config-manager.sh
+++ b/scripts/config/config-manager.sh
@@ -56,7 +56,8 @@ set_config_value() {
         exit 1
     fi
     
-    local project_root="$(dirname "$SCRIPT_DIR")"
+    # SCRIPT_DIR is scripts/config/; repo root (with the canonical config/ dir) is two up.
+    local project_root="$(dirname "$(dirname "$SCRIPT_DIR")")"
     local user_config_file="${project_root}/config/settings.local.conf"
     
     # Create user config file if it doesn't exist
@@ -162,7 +163,8 @@ test_production_connection() {
 }
 
 reset_configuration() {
-    local project_root="$(dirname "$SCRIPT_DIR")"
+    # SCRIPT_DIR is scripts/config/; repo root (with the canonical config/ dir) is two up.
+    local project_root="$(dirname "$(dirname "$SCRIPT_DIR")")"
     local user_config_file="${project_root}/config/settings.local.conf"
     
     echo "⚠️  This will reset your user configuration to defaults."


### PR DESCRIPTION
## Problem (Vikunja #2079, found during #2078)
`scripts/config/config-loader.sh` and `scripts/config/config-manager.sh` live two levels below the repo root, but both computed `project_root` as `dirname(script_dir)` = **`scripts/`**. So they read/wrote `scripts/config/settings.conf` and `scripts/config/settings.local.conf` — files that never exist. Meanwhile the version-controlled default (`config/settings.conf`), the `config-manager.sh` help text, and `api/config-loader.js` all use the **top-level `config/`** dir.

**Net effect:** the bash audit path silently ignored the tracked `config/settings.conf` and any operator edits to it, always falling back to loader defaults. (This is why the `/mnt/c/GIT` value in #2078 came from the loader default, not the config file.)

## Fix
Compute `project_root` as `dirname(dirname(script_dir))` = repo root in all **5** spots:
- `config-loader.sh`: `load_config`, `create_user_config`, `configure_interactive`
- `config-manager.sh`: `set_config_value`, `reset_configuration`

Matches the proven `scripts/phase2/*.sh` pattern and `api/config-loader.js` (`path.resolve(__dirname, '..')`).

## Verification
- **Read**: `load_config` now sources top-level `config/settings.local.conf` (marker `GITHUB_USER=MARKER123` picked up); nothing created under `scripts/config/`. ✅
- **Write**: `config-manager.sh set MAX_AUDIT_HISTORY 99` writes to top-level `config/settings.local.conf`; `scripts/config/` stays clean. ✅
- **No regression**: comprehensive audit still runs green/presence-only — now actually honoring `config/settings.conf` (`LOCAL_GIT_ROOT=""`). ✅
- `bash -n` clean; shellcheck shows only the pre-existing SC2155 on those `local x=$(...)` lines (unchanged from before).

## Prod safety
CT 123 has config only at top-level `/opt/gitops/config/settings.conf` (nothing under `scripts/config/`), so no config is orphaned. Ships on merge via the normal deploy (config/ + scripts/ replaced from repo).

## Out of scope (noted)
`api/config-loader.js:22` still hardcodes `LOCAL_GIT_ROOT: '/mnt/c/GIT'` as a JS default, but it's masked because `config/settings.conf` now sets `LOCAL_GIT_ROOT=""` and the JS loader reads that file. Minor consistency cleanup for later.

Fixes #2079 (Vikunja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)