### PR TITLE
fix(api): drop /mnt/c/GIT default in config-loader.js; LOCAL_GIT_ROOT opt-in

### DIFF
--- a/api/config-loader.js
+++ b/api/config-loader.js
@@ -19,7 +19,10 @@ class ConfigLoader {
       PRODUCTION_SERVER_USER: 'root',
       PRODUCTION_SERVER_PORT: '22',
       PRODUCTION_BASE_PATH: '/opt/gitops',
-      LOCAL_GIT_ROOT: '/mnt/c/GIT',
+      // Opt-in local clone mirror for the comprehensive audit; empty by default
+      // (presence-only where no mirror is maintained, e.g. the prod dashboard CT).
+      // Matches scripts/config/config-loader.sh. Override in config/settings.conf.
+      LOCAL_GIT_ROOT: '',
       DEVELOPMENT_API_PORT: '3070',
       DEVELOPMENT_DASHBOARD_PORT: '5173',
       GITHUB_USER: 'festion',
@@ -127,8 +130,8 @@ class ConfigLoader {
   validate() {
     const errors = [];
     
-    // Check required fields
-    const required = ['GITHUB_USER', 'LOCAL_GIT_ROOT', 'PRODUCTION_SERVER_IP'];
+    // Check required fields (LOCAL_GIT_ROOT is opt-in, validated below only if set)
+    const required = ['GITHUB_USER', 'PRODUCTION_SERVER_IP'];
     for (const field of required) {
       if (!this.get(field)) {
         errors.push(`Missing required configuration: ${field}`);
@@ -147,9 +150,11 @@ class ConfigLoader {
       errors.push(`Invalid dashboard port: ${dashboardPort}`);
     }
     
-    // Check if LOCAL_GIT_ROOT exists
-    if (!fs.existsSync(this.get('LOCAL_GIT_ROOT'))) {
-      errors.push(`Local Git root directory does not exist: ${this.get('LOCAL_GIT_ROOT')}`);
+    // LOCAL_GIT_ROOT is opt-in (empty => presence-only audit, no local mirror).
+    // Only validate the path when one is configured.
+    const localGitRoot = this.get('LOCAL_GIT_ROOT');
+    if (localGitRoot && !fs.existsSync(localGitRoot)) {
+      errors.push(`Local Git root directory does not exist: ${localGitRoot}`);
     }
     
     return errors;


### PR DESCRIPTION
## Problem (Vikunja #2080, found during #2079)
`api/config-loader.js:22` still hardcoded the leftover WSL path `LOCAL_GIT_ROOT: '/mnt/c/GIT'` as its JS default. Masked today (top-level `config/settings.conf` sets `LOCAL_GIT_ROOT=""` and the loader reads it), but a missing/empty settings.conf would resurface the bogus path — the last copy of `/mnt/c/GIT` in the codebase.

## Fix
- Default `LOCAL_GIT_ROOT` → `''` (opt-in), matching `scripts/config/config-loader.sh`.
- `validate()`: `LOCAL_GIT_ROOT` no longer in `required`; the `fs.existsSync` check runs **only when a value is configured** (empty ⇒ presence-only, not an error).

## Scope / safety
- The JS `LOCAL_GIT_ROOT` feeds only **display/logging** (`server.js` console output), not the audit itself (which uses the bash loader). `validate()` currently has **no callers**; the change keeps it self-consistent if ever wired up.
- **Verified**: empty ⇒ no git-root validation error; a configured-but-missing path still flags "does not exist"; `node --check` clean; **all 134 api jest tests pass**.

## Deliberately out of scope
`PRODUCTION_SERVER_IP: '192.168.1.58'` is stale (prod is `.136`/`gitopsdashboard.mgmt`) but it's stale in **both** this default and `config/settings.conf`, and fixing it correctly means touching config + verifying the dashboard's API/URL wiring — a separate change. Flagged for a follow-up rather than bundled here.

Fixes #2080 (Vikunja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)