### PR TITLE
fix(config): refresh PRODUCTION_SERVER_IP 192.168.1.58 -> .136 (gitopsdashboard)

### DIFF
--- a/api/config-loader.js
+++ b/api/config-loader.js
@@ -15,7 +15,7 @@ class ConfigLoader {
     
     // Set defaults
     this.config = {
-      PRODUCTION_SERVER_IP: '192.168.1.58',
+      PRODUCTION_SERVER_IP: '192.168.1.136',
       PRODUCTION_SERVER_USER: 'root',
       PRODUCTION_SERVER_PORT: '22',
       PRODUCTION_BASE_PATH: '/opt/gitops',

--- a/config/settings.conf
+++ b/config/settings.conf
@@ -2,7 +2,7 @@
 # This file contains user-configurable settings for the GitOps Auditor
 
 # Production Server Configuration
-PRODUCTION_SERVER_IP="192.168.1.58"
+PRODUCTION_SERVER_IP="192.168.1.136"
 PRODUCTION_SERVER_USER="root"
 PRODUCTION_SERVER_PORT="22"
 PRODUCTION_BASE_PATH="/opt/gitops"

--- a/scripts/config/config-loader.sh
+++ b/scripts/config/config-loader.sh
@@ -15,7 +15,7 @@ load_config() {
     local user_config_file="${project_root}/config/settings.local.conf"
     
     # Set defaults first
-    PRODUCTION_SERVER_IP="${PRODUCTION_SERVER_IP:-192.168.1.58}"
+    PRODUCTION_SERVER_IP="${PRODUCTION_SERVER_IP:-192.168.1.136}"
     PRODUCTION_SERVER_USER="${PRODUCTION_SERVER_USER:-root}"
     PRODUCTION_SERVER_PORT="${PRODUCTION_SERVER_PORT:-22}"
     PRODUCTION_BASE_PATH="${PRODUCTION_BASE_PATH:-/opt/gitops}"


### PR DESCRIPTION
## Problem (Vikunja #2081, from #2080 review)
`PRODUCTION_SERVER_IP` still defaulted to the dead `192.168.1.58`. Actual prod is CT 123 gitopsdashboard = **`192.168.1.136`** (`gitopsdashboard.mgmt.lakehouse.wtf`, API responds 200). Now actually consumed after #2079 (the tracked `config/settings.conf` is loaded), and it feeds `getApiUrl`/`getDashboardUrl` and `config-manager test-connection` (ping/ssh).

## Fix — 3 authoritative sources
- `config/settings.conf`
- `scripts/config/config-loader.sh` (bash default)
- `api/config-loader.js` (JS default)

## Verification
- JS loader → `getApiUrl(prod)` = `http://192.168.1.136:3070` ✅
- bash loader resolves `.136` from `config/settings.conf` ✅
- `node --check` + `bash -n` clean; **all 134 api jest tests pass** ✅

## Out of scope (tracked in #2081)
~40 stale `.58` references remain in docs (`*.md`), `output/CodeQualityReport.md`, `.serena/memories/*`, and phase2/archived deploy scripts. Notably `scripts/phase2/deploy-*.sh` still default `PRODUCTION_SERVER` to the dead `.58` (a footgun if anyone runs them). A broader sweep is deliberately separate from this config-value refresh.

Fixes #2081 (Vikunja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)