### PR TITLE
fix(phase2): default PRODUCTION_SERVER to .136, not dead .58

### DIFF
--- a/scripts/phase2/deploy-dashboard-v2.sh
+++ b/scripts/phase2/deploy-dashboard-v2.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.58}"
+PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.136}"
 DEPLOYMENT_USER="${DEPLOYMENT_USER:-root}"
 DEPLOYMENT_DIR="${DEPLOYMENT_DIR:-/opt/gitops}"
 

--- a/scripts/phase2/deploy-dependencies.sh
+++ b/scripts/phase2/deploy-dependencies.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.58}"
+PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.136}"
 DEPLOYMENT_USER="${DEPLOYMENT_USER:-root}"
 DEPLOYMENT_DIR="${DEPLOYMENT_DIR:-/opt/gitops}"
 

--- a/scripts/phase2/deploy-phase2-complete.sh
+++ b/scripts/phase2/deploy-phase2-complete.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.58}"
+PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.136}"
 DEPLOYMENT_USER="${DEPLOYMENT_USER:-root}"
 DEPLOYMENT_DIR="${DEPLOYMENT_DIR:-/opt/gitops}"
 LOG_FILE="${SCRIPT_DIR}/phase2-deployment-$(date +%Y%m%d_%H%M%S).log"

--- a/scripts/phase2/deploy-pipeline-engine.sh
+++ b/scripts/phase2/deploy-pipeline-engine.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.58}"
+PRODUCTION_SERVER="${PRODUCTION_SERVER:-192.168.1.136}"
 DEPLOYMENT_USER="${DEPLOYMENT_USER:-root}"
 DEPLOYMENT_DIR="${DEPLOYMENT_DIR:-/opt/gitops}"
 


### PR DESCRIPTION
## Problem (Vikunja #2081 remainder)
Four `scripts/phase2/deploy-*.sh` defaulted `PRODUCTION_SERVER` to the dead `192.168.1.58` (`${PRODUCTION_SERVER:-192.168.1.58}`). Running any of them without an explicit `PRODUCTION_SERVER` env override would ssh/scp/deploy to a non-existent host — the real footgun flagged in #2081.

## Fix
Default → `192.168.1.136` (CT 123 gitopsdashboard), matching `config/settings.conf` + both config-loaders:
- `deploy-dashboard-v2.sh`
- `deploy-dependencies.sh`
- `deploy-pipeline-engine.sh`
- `deploy-phase2-complete.sh`

## Notes
`bash -n` clean on all four. These are manual scripts, not wired into CI/`deploy.yml`, so no runtime path changes. Completes the actionable part of #2081; remaining `.58` refs are pure docs/serena-memory staleness (not worth churning).

Fixes #2081 (Vikunja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)