### PR TITLE
ci(dependabot): auto-merge patch/minor bumps after checks pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot patch/minor PRs once the branch-protection required
+# status checks (Unit Tests, lint-and-test) pass. Major version bumps are left
+# for manual review. `--auto` arms the merge but GATES it on those checks, so a
+# failing test never merges. Runs only for dependabot-authored PRs.
+#
+# The merge is enabled with a fine-grained PAT (DEPENDABOT_AUTOMERGE_TOKEN, a
+# Dependabot secret) rather than GITHUB_TOKEN, so the resulting push to main
+# TRIGGERS downstream deploy.yml — the bump deploys to CT 123 unattended.
+# GITHUB_TOKEN is only needed (read-only) by fetch-metadata.
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a Dependabot auto-merge workflow (Phase 1 pilot of the repo security-audit automation, Vikunja #2162).

- Patch/minor Dependabot PRs merge via `gh pr merge --auto --squash` **only after the required checks pass** (Unit Tests, lint-and-test). `--auto` arms the merge but gates it on those checks — a failing test never merges.
- **Major** bumps are skipped (`if:` clause) → left for manual review.
- Merge uses the fine-grained **`DEPENDABOT_AUTOMERGE_TOKEN`** (a Dependabot secret), **not** `GITHUB_TOKEN`, so the resulting push to `main` triggers `deploy.yml` and the bump deploys to CT 123 unattended (option B).
- `fetch-metadata` SHA-pinned to v3.1.0 per the repo's action-pinning convention; `GITHUB_TOKEN` scoped read-only.

## Review
Adversarially reviewed (Fable) for security + correctness: `pull_request` (not `pull_request_target`, no PR-code execution); no script-injection surface (`$PR_URL` via quoted env); `--auto` waits for checks; majors skip clean.

⚠️ **Behavioral note:** unreviewed patch/minor dependency bumps will deploy to the live CT 123 service once CI is green — the required checks are the only gate. This is the intended autonomous posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)