### PR TITLE
security(api): eliminate command-injection in git/mail operations (CodeQL, #2162)

### DIFF
--- a/api/createApp.js
+++ b/api/createApp.js
@@ -8,7 +8,9 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const { execFile } = require('child_process');
-const { execGit, execGitSeq, removeDir, isHttpGitUrl } = require('./lib/safe-exec');
+const {
+  execGit, execGitSeq, removeDir, isHttpGitUrl, resolveWithin,
+} = require('./lib/safe-exec');
 
 const SecurityMiddleware = require('./middleware/security');
 const authRoutes = require('./routes/auth');
@@ -169,7 +171,9 @@ function createApp({
       return res
         .status(400)
         .json({ error: 'clone_url must be an http(s)/ssh git URL' });
-    const dest = path.join(LOCAL_DIR, repo);
+    const dest = resolveWithin(LOCAL_DIR, repo);
+    if (!dest)
+      return res.status(400).json({ error: 'Invalid repo name' });
     execGit(['clone', '--', clone_url, dest], (err) => {
       if (err) return res.status(500).json({ error: `Failed to clone ${repo}` });
       res.json({ status: `Cloned ${repo} to ${dest}` });
@@ -179,7 +183,9 @@ function createApp({
   // Delete extra repository.
   app.post('/audit/delete', auditRateLimit, (req, res) => {
     const { repo } = req.body;
-    const target = path.join(LOCAL_DIR, repo);
+    const target = resolveWithin(LOCAL_DIR, repo);
+    if (!target)
+      return res.status(400).json({ error: 'Invalid repo name' });
     if (!fs.existsSync(target))
       return res.status(404).json({ error: 'Repo not found locally' });
     removeDir(target, (err) => {
@@ -191,7 +197,9 @@ function createApp({
   // Commit dirty repository.
   app.post('/audit/commit', auditRateLimit, (req, res) => {
     const { repo, message } = req.body;
-    const repoPath = path.join(LOCAL_DIR, repo);
+    const repoPath = resolveWithin(LOCAL_DIR, repo);
+    if (!repoPath)
+      return res.status(400).json({ error: 'Invalid repo name' });
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
     const commitMessage = message || 'Auto commit from GitOps audit';
@@ -217,7 +225,9 @@ function createApp({
         .status(400)
         .json({ error: 'expected_url must be an http(s)/ssh git URL' });
 
-    const repoPath = path.join(LOCAL_DIR, repo);
+    const repoPath = resolveWithin(LOCAL_DIR, repo);
+    if (!repoPath)
+      return res.status(400).json({ error: 'Invalid repo name' });
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
 
@@ -254,7 +264,10 @@ function createApp({
   // Get repository mismatch details.
   app.get('/audit/mismatch/:repo', auditRateLimit, (req, res) => {
     const repo = req.params.repo;
-    const repoPath = path.join(LOCAL_DIR, repo);
+    const repoPath = resolveWithin(LOCAL_DIR, repo);
+    if (!repoPath) {
+      return res.status(400).json({ error: 'Invalid repo name' });
+    }
 
     if (!fs.existsSync(path.join(repoPath, '.git'))) {
       return res.status(404).json({ error: 'Not a git repo' });
@@ -290,9 +303,16 @@ function createApp({
 
     repos.forEach((repo) => {
       let runner;
-      const repoPath = path.join(LOCAL_DIR, repo);
+      const repoPath = resolveWithin(LOCAL_DIR, repo);
       const githubUser =
         config && config.get ? config.get('GITHUB_USER') : '';
+
+      if (!repoPath) {
+        results.push({ repo, success: false, error: 'Invalid repo name', output: null });
+        completed++;
+        if (completed === repos.length) res.json({ operation, results });
+        return;
+      }
 
       switch (operation) {
         case 'clone':
@@ -341,7 +361,9 @@ function createApp({
   // Discard changes in dirty repo.
   app.post('/audit/discard', auditRateLimit, (req, res) => {
     const { repo } = req.body;
-    const repoPath = path.join(LOCAL_DIR, repo);
+    const repoPath = resolveWithin(LOCAL_DIR, repo);
+    if (!repoPath)
+      return res.status(400).json({ error: 'Invalid repo name' });
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
     execGitSeq(
@@ -357,7 +379,9 @@ function createApp({
   // Return status and diff for dirty repository.
   app.get('/audit/diff/:repo', auditRateLimit, (req, res) => {
     const repo = req.params.repo;
-    const repoPath = path.join(LOCAL_DIR, repo);
+    const repoPath = resolveWithin(LOCAL_DIR, repo);
+    if (!repoPath)
+      return res.status(400).json({ error: 'Invalid repo name' });
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
 

--- a/api/createApp.js
+++ b/api/createApp.js
@@ -7,7 +7,8 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
+const { execGit, execGitSeq, removeDir, isHttpGitUrl } = require('./lib/safe-exec');
 
 const SecurityMiddleware = require('./middleware/security');
 const authRoutes = require('./routes/auth');
@@ -164,8 +165,12 @@ function createApp({
     const { repo, clone_url } = req.body;
     if (!repo || !clone_url)
       return res.status(400).json({ error: 'repo and clone_url required' });
+    if (!isHttpGitUrl(clone_url))
+      return res
+        .status(400)
+        .json({ error: 'clone_url must be an http(s)/ssh git URL' });
     const dest = path.join(LOCAL_DIR, repo);
-    exec(`git clone ${clone_url} ${dest}`, (err) => {
+    execGit(['clone', '--', clone_url, dest], (err) => {
       if (err) return res.status(500).json({ error: `Failed to clone ${repo}` });
       res.json({ status: `Cloned ${repo} to ${dest}` });
     });
@@ -177,7 +182,7 @@ function createApp({
     const target = path.join(LOCAL_DIR, repo);
     if (!fs.existsSync(target))
       return res.status(404).json({ error: 'Repo not found locally' });
-    exec(`rm -rf ${target}`, (err) => {
+    removeDir(target, (err) => {
       if (err) return res.status(500).json({ error: `Failed to delete ${repo}` });
       res.json({ status: `Deleted ${repo}` });
     });
@@ -190,11 +195,14 @@ function createApp({
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
     const commitMessage = message || 'Auto commit from GitOps audit';
-    const cmd = `cd ${repoPath} && git add . && git commit -m "${commitMessage}"`;
-    exec(cmd, (err, stdout, stderr) => {
-      if (err) return res.status(500).json({ error: 'Commit failed', stderr });
-      res.json({ status: 'Committed changes', stdout });
-    });
+    execGitSeq(
+      [['add', '.'], ['commit', '-m', commitMessage]],
+      { cwd: repoPath },
+      (err, stdouts, stderr) => {
+        if (err) return res.status(500).json({ error: 'Commit failed', stderr });
+        res.json({ status: 'Committed changes', stdout: stdouts[stdouts.length - 1] });
+      }
+    );
   });
 
   // Fix remote URL mismatch.
@@ -204,19 +212,26 @@ function createApp({
       return res
         .status(400)
         .json({ error: 'repo and expected_url required' });
+    if (!isHttpGitUrl(expected_url))
+      return res
+        .status(400)
+        .json({ error: 'expected_url must be an http(s)/ssh git URL' });
 
     const repoPath = path.join(LOCAL_DIR, repo);
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
 
-    const cmd = `cd ${repoPath} && git remote set-url origin ${expected_url}`;
-    exec(cmd, (err, stdout, stderr) => {
-      if (err)
-        return res
-          .status(500)
-          .json({ error: 'Failed to fix remote URL', stderr });
-      res.json({ status: `Fixed remote URL for ${repo}`, stdout });
-    });
+    execGit(
+      ['remote', 'set-url', 'origin', expected_url],
+      { cwd: repoPath },
+      (err, stdout, stderr) => {
+        if (err)
+          return res
+            .status(500)
+            .json({ error: 'Failed to fix remote URL', stderr });
+        res.json({ status: `Fixed remote URL for ${repo}`, stdout });
+      }
+    );
   });
 
   // Run comprehensive audit script.
@@ -225,10 +240,9 @@ function createApp({
       ? path.join(rootDir, 'scripts/comprehensive_audit.sh')
       : '/opt/gitops/scripts/comprehensive_audit.sh';
 
-    const devFlag = isDev ? '--dev' : '';
-    const cmd = `bash ${scriptPath} ${devFlag}`;
+    const bashArgs = isDev ? [scriptPath, '--dev'] : [scriptPath];
 
-    exec(cmd, { timeout: 60000 }, (err, stdout, stderr) => {
+    execFile('bash', bashArgs, { timeout: 60000 }, (err, stdout, stderr) => {
       if (err)
         return res
           .status(500)
@@ -246,8 +260,7 @@ function createApp({
       return res.status(404).json({ error: 'Not a git repo' });
     }
 
-    const cmd = `cd ${repoPath} && git remote get-url origin`;
-    exec(cmd, (err, stdout) => {
+    execGit(['remote', 'get-url', 'origin'], { cwd: repoPath }, (err, stdout) => {
       if (err)
         return res.status(500).json({ error: 'Failed to get remote URL' });
 
@@ -276,24 +289,40 @@ function createApp({
     let completed = 0;
 
     repos.forEach((repo) => {
-      let cmd;
+      let runner;
       const repoPath = path.join(LOCAL_DIR, repo);
+      const githubUser =
+        config && config.get ? config.get('GITHUB_USER') : '';
 
       switch (operation) {
         case 'clone':
-          cmd = `git clone https://github.com/${config && config.get ? config.get('GITHUB_USER') : ''}/${repo}.git ${repoPath}`;
+          runner = (cb) =>
+            execGit(
+              ['clone', '--', `https://github.com/${githubUser}/${repo}.git`, repoPath],
+              cb
+            );
           break;
         case 'fix-remote':
-          cmd = `cd ${repoPath} && git remote set-url origin https://github.com/${config && config.get ? config.get('GITHUB_USER') : ''}/${repo}.git`;
+          runner = (cb) =>
+            execGit(
+              [
+                'remote',
+                'set-url',
+                'origin',
+                `https://github.com/${githubUser}/${repo}.git`,
+              ],
+              { cwd: repoPath },
+              cb
+            );
           break;
         case 'delete':
-          cmd = `rm -rf ${repoPath}`;
+          runner = (cb) => removeDir(repoPath, cb);
           break;
         default:
           return res.status(400).json({ error: 'Invalid operation' });
       }
 
-      exec(cmd, (err, stdout, stderr) => {
+      runner((err, stdout) => {
         results.push({
           repo,
           success: !err,
@@ -315,11 +344,14 @@ function createApp({
     const repoPath = path.join(LOCAL_DIR, repo);
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
-    const cmd = `cd ${repoPath} && git reset --hard && git clean -fd`;
-    exec(cmd, (err) => {
-      if (err) return res.status(500).json({ error: 'Discard failed' });
-      res.json({ status: 'Discarded changes' });
-    });
+    execGitSeq(
+      [['reset', '--hard'], ['clean', '-fd']],
+      { cwd: repoPath },
+      (err) => {
+        if (err) return res.status(500).json({ error: 'Discard failed' });
+        res.json({ status: 'Discarded changes' });
+      }
+    );
   });
 
   // Return status and diff for dirty repository.
@@ -329,11 +361,14 @@ function createApp({
     if (!fs.existsSync(path.join(repoPath, '.git')))
       return res.status(404).json({ error: 'Not a git repo' });
 
-    const cmd = `cd ${repoPath} && git status --short && echo '---' && git diff`;
-    exec(cmd, (err, stdout) => {
-      if (err) return res.status(500).json({ error: 'Diff failed' });
-      res.json({ repo, diff: stdout });
-    });
+    execGitSeq(
+      [['status', '--short'], ['diff']],
+      { cwd: repoPath },
+      (err, stdouts) => {
+        if (err) return res.status(500).json({ error: 'Diff failed' });
+        res.json({ repo, diff: `${stdouts[0]}---\n${stdouts[1]}` });
+      }
+    );
   });
 
   // GitHub Webhook endpoint raw-body pre-middleware.

--- a/api/email-notifications.js
+++ b/api/email-notifications.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 
 /**
  * Configuration for email notifications
@@ -147,24 +147,53 @@ function sendEmail(subject, htmlContent, toEmail) {
       return;
     }
 
+    // The recipient is passed as a positional argv element to `mail`. Reject
+    // anything that isn't a plain address — in particular a value starting with
+    // '-', which mail/mailx would parse as an OPTION (argument injection).
+    if (typeof toEmail !== 'string' || !/^[^\s@-][^\s@]*@[^\s@]+\.[^\s@]+$/.test(toEmail)) {
+      reject(new Error('Invalid recipient email address'));
+      return;
+    }
+
     const fullSubject = `${EMAIL_CONFIG.SUBJECT_PREFIX} ${subject}`;
     
     // Create temporary HTML file
     const tempFile = path.join('/tmp', `gitops-email-${Date.now()}.html`);
     fs.writeFileSync(tempFile, htmlContent);
     
-    // Send email using mail command (works with most Unix systems)
-    const mailCommand = `mail -s "${fullSubject}" -a "Content-Type: text/html" "${toEmail}" < "${tempFile}"`;
-    
-    exec(mailCommand, (error, stdout, stderr) => {
-      // Clean up temp file
+    // Send email using the `mail` command (works with most Unix systems).
+    // Use spawn with an argument array + feed the body on stdin (no shell), so
+    // a crafted subject / recipient can never inject shell commands. The old
+    // `mail -s "${subject}" "${to}" < "${file}"` string went through /bin/sh.
+    const cleanup = () => {
       try {
         fs.unlinkSync(tempFile);
       } catch (e) {
         console.warn('⚠️ Failed to clean up temp email file:', e.message);
       }
-      
-      if (error) {
+    };
+
+    const mail = spawn('mail', [
+      '-s', fullSubject,
+      '-a', 'Content-Type: text/html',
+      toEmail,
+    ]);
+    let mailStderr = '';
+    mail.stderr.on('data', (chunk) => { mailStderr += chunk.toString(); });
+    // Ignore EPIPE if `mail` exits before consuming all of stdin; the exit code
+    // is handled by the 'close' listener below.
+    mail.stdin.on('error', () => {});
+
+    mail.on('error', (error) => {
+      cleanup();
+      console.error('❌ Failed to send email:', error.message);
+      reject(error);
+    });
+
+    mail.on('close', (code) => {
+      cleanup();
+      if (code !== 0) {
+        const error = new Error(`mail exited with code ${code}: ${mailStderr.trim()}`);
         console.error('❌ Failed to send email:', error.message);
         reject(error);
       } else {
@@ -172,6 +201,16 @@ function sendEmail(subject, htmlContent, toEmail) {
         resolve(true);
       }
     });
+
+    // Feed the HTML body to `mail` on stdin (replaces the old `< tempFile` shell
+    // redirect). A stream error is surfaced through the child's error handler.
+    const bodyStream = fs.createReadStream(tempFile);
+    bodyStream.on('error', (error) => {
+      cleanup();
+      console.error('❌ Failed to read email body:', error.message);
+      reject(error);
+    });
+    bodyStream.pipe(mail.stdin);
   });
 }
 

--- a/api/github-mcp-manager.js
+++ b/api/github-mcp-manager.js
@@ -7,7 +7,7 @@
  * All operations are orchestrated through Serena for optimal workflow coordination.
  */
 
-const { execGit, execGitSeq, isHttpGitUrl } = require('./lib/safe-exec');
+const { execGit, execGitSeq, isHttpGitUrl, sanitizeForLog } = require('./lib/safe-exec');
 const fs = require('fs');
 const path = require('path');
 const SerenaOrchestrator = require('./serena-orchestrator');
@@ -314,7 +314,7 @@ class GitHubMCPManager {
                 { cwd: repoPath },
                 (err, stdouts, stderr) => {
                     if (err) {
-                        console.error(`❌ Git commit failed for ${repoName}:`, stderr);
+                        console.error('❌ Git commit failed for %s:', sanitizeForLog(repoName), stderr);
                         reject(new Error(`Commit failed: ${stderr}`));
                     } else {
                         console.log(`✅ Successfully committed changes in ${repoName}`);
@@ -463,7 +463,7 @@ class GitHubMCPManager {
                 { cwd: repoPath },
                 (err, stdouts, stderr) => {
                     if (err) {
-                        console.error(`❌ Git discard failed for ${repoName}:`, stderr);
+                        console.error('❌ Git discard failed for %s:', sanitizeForLog(repoName), stderr);
                         reject(new Error('Discard failed'));
                     } else {
                         console.log(`✅ Successfully discarded changes in ${repoName}`);
@@ -514,7 +514,7 @@ class GitHubMCPManager {
                 { cwd: repoPath },
                 (err, stdouts, stderr) => {
                     if (err) {
-                        console.error(`❌ Git diff failed for ${repoName}:`, stderr);
+                        console.error('❌ Git diff failed for %s:', sanitizeForLog(repoName), stderr);
                         reject(new Error('Diff failed'));
                     } else {
                         console.log(`✅ Successfully retrieved diff for ${repoName}`);

--- a/api/github-mcp-manager.js
+++ b/api/github-mcp-manager.js
@@ -7,7 +7,7 @@
  * All operations are orchestrated through Serena for optimal workflow coordination.
  */
 
-const { exec } = require('child_process');
+const { execGit, execGitSeq, isHttpGitUrl } = require('./lib/safe-exec');
 const fs = require('fs');
 const path = require('path');
 const SerenaOrchestrator = require('./serena-orchestrator');
@@ -219,9 +219,11 @@ class GitHubMCPManager {
     async cloneRepositoryFallback(repoName, cloneUrl, destPath) {
         return new Promise((resolve, reject) => {
             console.log(`📥 Cloning ${repoName} via git fallback...`);
-            
-            const cmd = `git clone ${cloneUrl} ${destPath}`;
-            exec(cmd, (err, stdout, stderr) => {
+
+            if (!isHttpGitUrl(cloneUrl)) {
+                return reject(new Error(`Invalid clone URL for ${repoName}`));
+            }
+            execGit(['clone', '--', cloneUrl, destPath], (err, stdout, stderr) => {
                 if (err) {
                     console.error(`❌ Git clone failed for ${repoName}:`, stderr);
                     reject(new Error(`Failed to clone ${repoName}: ${stderr}`));
@@ -307,16 +309,19 @@ class GitHubMCPManager {
         return new Promise((resolve, reject) => {
             console.log(`💾 Committing changes in ${repoName} via git fallback...`);
             
-            const cmd = `cd ${repoPath} && git add . && git commit -m "${message}"`;
-            exec(cmd, (err, stdout, stderr) => {
-                if (err) {
-                    console.error(`❌ Git commit failed for ${repoName}:`, stderr);
-                    reject(new Error(`Commit failed: ${stderr}`));
-                } else {
-                    console.log(`✅ Successfully committed changes in ${repoName}`);
-                    resolve({ status: `Committed changes in ${repoName}`, stdout });
+            execGitSeq(
+                [['add', '.'], ['commit', '-m', message]],
+                { cwd: repoPath },
+                (err, stdouts, stderr) => {
+                    if (err) {
+                        console.error(`❌ Git commit failed for ${repoName}:`, stderr);
+                        reject(new Error(`Commit failed: ${stderr}`));
+                    } else {
+                        console.log(`✅ Successfully committed changes in ${repoName}`);
+                        resolve({ status: `Committed changes in ${repoName}`, stdout: stdouts[stdouts.length - 1] });
+                    }
                 }
-            });
+            );
         });
     }
 
@@ -355,9 +360,11 @@ class GitHubMCPManager {
     async updateRemoteUrlFallback(repoName, repoPath, newUrl) {
         return new Promise((resolve, reject) => {
             console.log(`🔗 Updating remote URL for ${repoName} via git fallback...`);
-            
-            const cmd = `cd ${repoPath} && git remote set-url origin ${newUrl}`;
-            exec(cmd, (err, stdout, stderr) => {
+
+            if (!isHttpGitUrl(newUrl)) {
+                return reject(new Error(`Invalid remote URL for ${repoName}`));
+            }
+            execGit(['remote', 'set-url', 'origin', newUrl], { cwd: repoPath }, (err, stdout, stderr) => {
                 if (err) {
                     console.error(`❌ Git remote update failed for ${repoName}:`, stderr);
                     reject(new Error(`Failed to fix remote URL: ${stderr}`));
@@ -404,8 +411,7 @@ class GitHubMCPManager {
         return new Promise((resolve, reject) => {
             console.log(`🔍 Getting remote URL for ${repoName} via git fallback...`);
             
-            const cmd = `cd ${repoPath} && git remote get-url origin`;
-            exec(cmd, (err, stdout, stderr) => {
+            execGit(['remote', 'get-url', 'origin'], { cwd: repoPath }, (err, stdout, stderr) => {
                 if (err) {
                     console.error(`❌ Git get remote failed for ${repoName}:`, stderr);
                     reject(new Error('Failed to get remote URL'));
@@ -452,16 +458,19 @@ class GitHubMCPManager {
         return new Promise((resolve, reject) => {
             console.log(`🗑️  Discarding changes in ${repoName} via git fallback...`);
             
-            const cmd = `cd ${repoPath} && git reset --hard && git clean -fd`;
-            exec(cmd, (err, stdout, stderr) => {
-                if (err) {
-                    console.error(`❌ Git discard failed for ${repoName}:`, stderr);
-                    reject(new Error('Discard failed'));
-                } else {
-                    console.log(`✅ Successfully discarded changes in ${repoName}`);
-                    resolve({ status: 'Discarded changes', stdout });
+            execGitSeq(
+                [['reset', '--hard'], ['clean', '-fd']],
+                { cwd: repoPath },
+                (err, stdouts, stderr) => {
+                    if (err) {
+                        console.error(`❌ Git discard failed for ${repoName}:`, stderr);
+                        reject(new Error('Discard failed'));
+                    } else {
+                        console.log(`✅ Successfully discarded changes in ${repoName}`);
+                        resolve({ status: 'Discarded changes', stdout: stdouts[stdouts.length - 1] });
+                    }
                 }
-            });
+            );
         });
     }
 
@@ -500,16 +509,20 @@ class GitHubMCPManager {
         return new Promise((resolve, reject) => {
             console.log(`📊 Getting repository diff for ${repoName} via git fallback...`);
             
-            const cmd = `cd ${repoPath} && git status --short && echo '---' && git diff`;
-            exec(cmd, (err, stdout, stderr) => {
-                if (err) {
-                    console.error(`❌ Git diff failed for ${repoName}:`, stderr);
-                    reject(new Error('Diff failed'));
-                } else {
-                    console.log(`✅ Successfully retrieved diff for ${repoName}`);
-                    resolve({ diff: stdout, stdout });
+            execGitSeq(
+                [['status', '--short'], ['diff']],
+                { cwd: repoPath },
+                (err, stdouts, stderr) => {
+                    if (err) {
+                        console.error(`❌ Git diff failed for ${repoName}:`, stderr);
+                        reject(new Error('Diff failed'));
+                    } else {
+                        console.log(`✅ Successfully retrieved diff for ${repoName}`);
+                        const combined = `${stdouts[0]}---\n${stdouts[1]}`;
+                        resolve({ diff: combined, stdout: combined });
+                    }
                 }
-            });
+            );
         });
     }
 

--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -121,7 +121,8 @@ module.exports = {
         '<rootDir>/tests/routes/*.test.js',
         '<rootDir>/tests/services/*.test.js',
         '<rootDir>/tests/middleware/*.test.js',
-        '<rootDir>/tests/models/*.test.js'
+        '<rootDir>/tests/models/*.test.js',
+        '<rootDir>/tests/lib/*.test.js'
       ],
       setupFilesAfterEnv: [
         '<rootDir>/tests/setup/jest.setup.js',

--- a/api/lib/safe-exec.js
+++ b/api/lib/safe-exec.js
@@ -1,0 +1,78 @@
+'use strict';
+// Shell-free helpers for running git / filesystem operations from request
+// handlers. They exist to remove the js/command-line-injection class: the old
+// code built a shell string like `git commit -m "${message}"` and passed it to
+// child_process.exec (which spawns /bin/sh), so any metacharacter in a
+// user-supplied value (repo name, commit message, URL, path) could inject
+// arbitrary commands. execFile / fs.rm take the command and its arguments
+// separately and never involve a shell, so values are always literal data.
+const { execFile, execFileSync } = require('child_process');
+const { promisify } = require('util');
+const fs = require('fs');
+const execFileP = promisify(execFile);
+
+// Run `git <args>` with no shell. Signature mirrors child_process.execFile's
+// (args, [options], callback); options accepts e.g. { cwd }.
+function execGit(args, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  return execFile('git', args, options || {}, callback);
+}
+
+// Run several git invocations sequentially in the same options (e.g. cwd),
+// aborting on the first error — the safe equivalent of shell `git a && git b`.
+// `steps` is an array of arg-arrays. Calls back (err, stdouts, stderr): on
+// success `stdouts` holds each step's stdout in order; on error it holds the
+// stdout collected so far and `stderr` is the failing step's stderr.
+function execGitSeq(steps, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  const stdouts = [];
+  const run = (i) => {
+    if (i >= steps.length) return callback(null, stdouts);
+    execGit(steps[i], options, (err, stdout, stderr) => {
+      if (err) return callback(err, stdouts, stderr);
+      stdouts.push(stdout);
+      run(i + 1);
+    });
+  };
+  run(0);
+}
+
+// Synchronous shell-free git (replaces `execSync(`git ... ${x}`)`). Returns
+// stdout as a utf8 string by default; throws like execFileSync on non-zero exit.
+function execGitSync(args, options) {
+  return execFileSync('git', args, { encoding: 'utf8', ...(options || {}) });
+}
+
+// Promise form of shell-free git (replaces an `await`ed shell `exec`). Resolves
+// with stdout, rejects on non-zero exit.
+async function execGitP(args, options) {
+  const { stdout } = await execFileP('git', args, options || {});
+  return stdout;
+}
+
+// Recursively remove a directory with no shell — replaces `rm -rf ${path}`.
+// force:true so a missing path is not an error (matches `rm -rf`).
+function removeDir(target, callback) {
+  fs.rm(target, { recursive: true, force: true }, callback);
+}
+
+// True only for git remote URLs that use an expected transport scheme. Passing
+// a raw request value as a positional git argument is unsafe even without a
+// shell: a value beginning with '-' is parsed as an OPTION (argument injection,
+// e.g. `--upload-pack=…` → command execution), and transports like `ext::` /
+// `file::` let git run arbitrary programs. Reject anything that is not plain
+// http(s)/ssh/scp-style before it reaches `git clone` / `git remote set-url`.
+function isHttpGitUrl(url) {
+  return typeof url === 'string'
+    && /^(https?:\/\/|ssh:\/\/|git@[\w.-]+:)/.test(url);
+}
+
+module.exports = {
+  execGit, execGitSeq, execGitSync, execGitP, removeDir, isHttpGitUrl,
+};

--- a/api/lib/safe-exec.js
+++ b/api/lib/safe-exec.js
@@ -9,6 +9,7 @@
 const { execFile, execFileSync } = require('child_process');
 const { promisify } = require('util');
 const fs = require('fs');
+const path = require('path');
 const execFileP = promisify(execFile);
 
 // Run `git <args>` with no shell. Signature mirrors child_process.execFile's
@@ -73,6 +74,33 @@ function isHttpGitUrl(url) {
     && /^(https?:\/\/|ssh:\/\/|git@[\w.-]+:)/.test(url);
 }
 
+// Resolve a user-supplied name (e.g. a repo name from req.body) to an absolute
+// path CONTAINED within baseDir, or null if it escapes (a `..` traversal or an
+// absolute path) or is empty. Using the returned value as a filesystem / cwd
+// argument is the barrier for path-injection (CVE-class: arbitrary file/dir
+// access — e.g. `/audit/delete` with repo="../../etc"). Mirrors the repo's
+// existing templateEngine._resolveWithinRoot pattern.
+function resolveWithin(baseDir, name) {
+  if (typeof name !== 'string' || name.length === 0) return null;
+  const rootAbs = path.resolve(baseDir);
+  const resolved = path.resolve(rootAbs, name);
+  const rel = path.relative(rootAbs, resolved);
+  if (rel === '' || rel === '..' || rel.startsWith('..' + path.sep)
+      || path.isAbsolute(rel)) {
+    return null;
+  }
+  return resolved;
+}
+
+// Neutralise a value before it is logged: strip control characters (log /
+// format-string injection) and cap length. Mirrors templateEngine.sanitizeForLog.
+function sanitizeForLog(value) {
+  const s = value === null ? 'null'
+    : value === undefined ? 'undefined' : String(value);
+  return s.replace(/[\u0000-\u001F\u007F]/g, ' ').slice(0, 500);
+}
+
 module.exports = {
   execGit, execGitSeq, execGitSync, execGitP, removeDir, isHttpGitUrl,
+  resolveWithin, sanitizeForLog,
 };

--- a/api/phase2-endpoints.js
+++ b/api/phase2-endpoints.js
@@ -2,7 +2,6 @@
 // Extends the main API server with Phase 2 DevOps platform features
 
 const express = require('express');
-const { exec } = require('child_process');
 const fs = require('fs').promises;
 const path = require('path');
 const { randomUUID } = require('node:crypto');

--- a/api/server-mcp.js
+++ b/api/server-mcp.js
@@ -10,7 +10,7 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { exec } = require('child_process');
+const { removeDir } = require('./lib/safe-exec');
 
 // Load configuration and GitHub MCP manager
 const ConfigLoader = require('./config-loader');
@@ -461,7 +461,7 @@ app.post('/audit/delete', (req, res) => {
   }
   
   console.log(`🗑️  Deleting extra repository: ${repo}`);
-  exec(`rm -rf ${target}`, async (err) => {
+  removeDir(target, async (err) => {
     if (err) {
       console.error(`❌ Delete failed for ${repo}:`, err);
       return res.status(500).json({ error: `Failed to delete ${repo}` });
@@ -617,7 +617,7 @@ if (isDev) {
           case 'delete':
             // Delete operation doesn't use MCP (file system operation)
             await new Promise((resolve, reject) => {
-              exec(`rm -rf ${repoPath}`, (err) => {
+              removeDir(repoPath, (err) => {
                 if (err) reject(err);
                 else resolve();
               });

--- a/api/server-mcp.js
+++ b/api/server-mcp.js
@@ -10,7 +10,7 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { removeDir } = require('./lib/safe-exec');
+const { removeDir, resolveWithin } = require('./lib/safe-exec');
 
 // Load configuration and GitHub MCP manager
 const ConfigLoader = require('./config-loader');
@@ -430,7 +430,7 @@ app.post('/audit/clone', async (req, res) => {
   
   try {
     console.log(`🔄 Cloning repository: ${repo}`);
-    const dest = path.join(LOCAL_DIR, repo);
+    const dest = resolveWithin(LOCAL_DIR, repo);
     
     // Use GitHub MCP manager for cloning
     const result = await githubMCP.cloneRepository(repo, clone_url, dest);
@@ -454,7 +454,7 @@ app.post('/audit/clone', async (req, res) => {
 // Delete extra repository
 app.post('/audit/delete', (req, res) => {
   const { repo } = req.body;
-  const target = path.join(LOCAL_DIR, repo);
+  const target = resolveWithin(LOCAL_DIR, repo);
   
   if (!fs.existsSync(target)) {
     return res.status(404).json({ error: 'Repo not found locally' });
@@ -489,7 +489,7 @@ app.post('/audit/delete', (req, res) => {
 // Commit dirty repository using GitHub MCP
 app.post('/audit/commit', async (req, res) => {
   const { repo, message } = req.body;
-  const repoPath = path.join(LOCAL_DIR, repo);
+  const repoPath = resolveWithin(LOCAL_DIR, repo);
   
   if (!githubMCP.isGitRepository(repoPath)) {
     return res.status(404).json({ error: 'Not a git repo' });
@@ -527,7 +527,7 @@ if (isDev) {
       return res.status(400).json({ error: 'repo and expected_url required' });
     }
     
-    const repoPath = path.join(LOCAL_DIR, repo);
+    const repoPath = resolveWithin(LOCAL_DIR, repo);
     
     if (!githubMCP.isGitRepository(repoPath)) {
       return res.status(404).json({ error: 'Not a git repo' });
@@ -558,7 +558,7 @@ if (isDev) {
   // Get repository mismatch details using GitHub MCP
   app.get('/audit/mismatch/:repo', async (req, res) => {
     const repo = req.params.repo;
-    const repoPath = path.join(LOCAL_DIR, repo);
+    const repoPath = resolveWithin(LOCAL_DIR, repo);
 
     if (!githubMCP.isGitRepository(repoPath)) {
       return res.status(404).json({ error: 'Not a git repo' });
@@ -598,7 +598,7 @@ if (isDev) {
     let completed = 0;
 
     for (const repo of repos) {
-      const repoPath = path.join(LOCAL_DIR, repo);
+      const repoPath = resolveWithin(LOCAL_DIR, repo);
       
       try {
         let result;
@@ -658,7 +658,7 @@ if (isDev) {
 // Discard changes in dirty repo using GitHub MCP
 app.post('/audit/discard', async (req, res) => {
   const { repo } = req.body;
-  const repoPath = path.join(LOCAL_DIR, repo);
+  const repoPath = resolveWithin(LOCAL_DIR, repo);
   
   if (!githubMCP.isGitRepository(repoPath)) {
     return res.status(404).json({ error: 'Not a git repo' });
@@ -689,7 +689,7 @@ app.post('/audit/discard', async (req, res) => {
 // Return status and diff for dirty repository using GitHub MCP
 app.get('/audit/diff/:repo', async (req, res) => {
   const repo = req.params.repo;
-  const repoPath = path.join(LOCAL_DIR, repo);
+  const repoPath = resolveWithin(LOCAL_DIR, repo);
   
   if (!githubMCP.isGitRepository(repoPath)) {
     return res.status(404).json({ error: 'Not a git repo' });

--- a/api/server-v2.js
+++ b/api/server-v2.js
@@ -10,7 +10,7 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { exec } = require('child_process');
+const { removeDir } = require('./lib/safe-exec');
 
 // Load configuration and GitHub MCP manager
 const ConfigLoader = require('./config-loader');
@@ -163,7 +163,7 @@ app.post('/audit/delete', (req, res) => {
   }
   
   console.log(`🗑️  Deleting extra repository: ${repo}`);
-  exec(`rm -rf ${target}`, async (err) => {
+  removeDir(target, async (err) => {
     if (err) {
       console.error(`❌ Delete failed for ${repo}:`, err);
       return res.status(500).json({ error: `Failed to delete ${repo}` });

--- a/api/server-v2.js
+++ b/api/server-v2.js
@@ -10,7 +10,7 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { removeDir } = require('./lib/safe-exec');
+const { removeDir, resolveWithin } = require('./lib/safe-exec');
 
 // Load configuration and GitHub MCP manager
 const ConfigLoader = require('./config-loader');
@@ -132,7 +132,7 @@ app.post('/audit/clone', async (req, res) => {
   
   try {
     console.log(`🔄 Cloning repository: ${repo}`);
-    const dest = path.join(LOCAL_DIR, repo);
+    const dest = resolveWithin(LOCAL_DIR, repo);
     
     // Use GitHub MCP manager for cloning
     const result = await githubMCP.cloneRepository(repo, clone_url, dest);
@@ -156,7 +156,7 @@ app.post('/audit/clone', async (req, res) => {
 // Delete extra repository
 app.post('/audit/delete', (req, res) => {
   const { repo } = req.body;
-  const target = path.join(LOCAL_DIR, repo);
+  const target = resolveWithin(LOCAL_DIR, repo);
   
   if (!fs.existsSync(target)) {
     return res.status(404).json({ error: 'Repo not found locally' });
@@ -177,7 +177,7 @@ app.post('/audit/delete', (req, res) => {
 // Commit dirty repository using GitHub MCP
 app.post('/audit/commit', async (req, res) => {
   const { repo, message } = req.body;
-  const repoPath = path.join(LOCAL_DIR, repo);
+  const repoPath = resolveWithin(LOCAL_DIR, repo);
   
   if (!githubMCP.isGitRepository(repoPath)) {
     return res.status(404).json({ error: 'Not a git repo' });
@@ -199,7 +199,7 @@ app.post('/audit/commit', async (req, res) => {
 // Discard changes in dirty repo using GitHub MCP
 app.post('/audit/discard', async (req, res) => {
   const { repo } = req.body;
-  const repoPath = path.join(LOCAL_DIR, repo);
+  const repoPath = resolveWithin(LOCAL_DIR, repo);
   
   if (!githubMCP.isGitRepository(repoPath)) {
     return res.status(404).json({ error: 'Not a git repo' });
@@ -220,7 +220,7 @@ app.post('/audit/discard', async (req, res) => {
 // Return status and diff for dirty repository using GitHub MCP
 app.get('/audit/diff/:repo', async (req, res) => {
   const repo = req.params.repo;
-  const repoPath = path.join(LOCAL_DIR, repo);
+  const repoPath = resolveWithin(LOCAL_DIR, repo);
   
   if (!githubMCP.isGitRepository(repoPath)) {
     return res.status(404).json({ error: 'Not a git repo' });

--- a/api/services/metrics/collectors/repositoryCollector.js
+++ b/api/services/metrics/collectors/repositoryCollector.js
@@ -7,6 +7,7 @@
 
 const EventEmitter = require('events');
 const { exec } = require('child_process');
+const { execGitP } = require('../../../lib/safe-exec');
 const fs = require('fs');
 const path = require('path');
 const { RepositoryMetrics } = require('../../../models/metrics');
@@ -133,7 +134,12 @@ class RepositoryCollector extends EventEmitter {
             let staleCount = 0;
             for (const tag of tagList.slice(0, 10)) { // Check last 10 tags
                 try {
-                    const tagDate = await this.execCommand(`git log -1 --format=%ct ${tag}`, repoPath);
+                    // Tag name comes from the (untrusted) cloned repo — run with
+                    // no shell and via refs/tags/ so it can't be a git option.
+                    const tagDate = await execGitP(
+                        ['log', '-1', '--format=%ct', `refs/tags/${tag}`],
+                        { cwd: repoPath, timeout: 30000 }
+                    );
                     const tagTimestamp = parseInt(tagDate.trim()) * 1000;
                     const sixMonthsAgo = Date.now() - (6 * 30 * 24 * 60 * 60 * 1000);
                     

--- a/api/services/searchService.js
+++ b/api/services/searchService.js
@@ -233,6 +233,7 @@ class SearchService {
       }
 
       const { execSync } = require('child_process');
+      const { execGitSync } = require('../lib/safe-exec');
       const tags = execSync(
         'git tag --sort=-creatordate',
         { cwd: repo.local_path, encoding: 'utf8' }
@@ -240,10 +241,12 @@ class SearchService {
 
       if (tags.length === 0) return false;
 
-      // Check if latest tag is older than 6 months
-      const latestTagDate = execSync(
-        `git log -1 --format=%ci ${tags[0]}`,
-        { cwd: repo.local_path, encoding: 'utf8' }
+      // Check if latest tag is older than 6 months. The tag name comes from the
+      // cloned (untrusted) repo, so pass it as a literal argv element with no
+      // shell and via refs/tags/ so it can never be parsed as a git option.
+      const latestTagDate = execGitSync(
+        ['log', '-1', '--format=%ci', `refs/tags/${tags[0]}`],
+        { cwd: repo.local_path }
       ).trim();
 
       const tagAge = Date.now() - new Date(latestTagDate).getTime();

--- a/api/tests/lib/safe-exec.test.js
+++ b/api/tests/lib/safe-exec.test.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 
 const {
   execGit, execGitSeq, execGitSync, execGitP, removeDir, isHttpGitUrl,
+  resolveWithin, sanitizeForLog,
 } = require('../../lib/safe-exec');
 
 function mkTmp() {
@@ -153,6 +154,42 @@ describe('isHttpGitUrl (remote-URL argument guard)', () => {
     ]) {
       expect(isHttpGitUrl(u)).toBe(false);
     }
+  });
+});
+
+describe('resolveWithin (path-traversal containment)', () => {
+  const base = '/srv/repos';
+
+  test('resolves a simple name inside the base', () => {
+    expect(resolveWithin(base, 'my-repo')).toBe(path.resolve(base, 'my-repo'));
+  });
+
+  test('allows a nested subpath that stays inside', () => {
+    expect(resolveWithin(base, 'org/repo')).toBe(path.resolve(base, 'org/repo'));
+  });
+
+  test('rejects traversal, absolute paths, and the base itself', () => {
+    for (const n of ['../etc', 'a/../../etc', '/etc/passwd', '.', '', '..']) {
+      expect(resolveWithin(base, n)).toBeNull();
+    }
+  });
+
+  test('rejects non-string names', () => {
+    for (const n of [null, undefined, 42, {}]) {
+      expect(resolveWithin(base, n)).toBeNull();
+    }
+  });
+});
+
+describe('sanitizeForLog', () => {
+  test('strips control characters (log / format-string injection)', () => {
+    expect(sanitizeForLog('a\nb\tc\rd')).toBe('a b c d');
+  });
+
+  test('caps length at 500 and stringifies null/undefined', () => {
+    expect(sanitizeForLog('x'.repeat(600))).toHaveLength(500);
+    expect(sanitizeForLog(null)).toBe('null');
+    expect(sanitizeForLog(undefined)).toBe('undefined');
   });
 });
 

--- a/api/tests/lib/safe-exec.test.js
+++ b/api/tests/lib/safe-exec.test.js
@@ -1,0 +1,177 @@
+// Security regression tests for lib/safe-exec.js (CodeQL js/command-line-injection).
+//
+// The 18 critical command-injection alerts on this API all came from building a
+// shell string like `git commit -m "${message}"` and passing it to
+// child_process.exec (which spawns /bin/sh). These helpers run the same git /
+// filesystem operations with NO shell, so an attacker-controlled value can never
+// be interpreted as a command. These tests prove that property directly.
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+const {
+  execGit, execGitSeq, execGitSync, execGitP, removeDir, isHttpGitUrl,
+} = require('../../lib/safe-exec');
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'safeexec-'));
+}
+
+function initRepo(dir, cb) {
+  execGit(['init', '-q'], { cwd: dir }, () =>
+    execGit(['config', 'user.email', 't@example.com'], { cwd: dir }, () =>
+      execGit(['config', 'user.name', 'Test'], { cwd: dir }, () => cb())));
+}
+
+describe('safe-exec execGit / execGitSeq (no shell)', () => {
+  test('a shell-metacharacter commit message is stored LITERALLY and does not execute', (done) => {
+    const dir = mkTmp();
+    initRepo(dir, () => {
+      fs.writeFileSync(path.join(dir, 'file.txt'), 'content');
+      // In a shell this closes the -m quote and runs `touch INJECTED`.
+      const payload = '"; touch INJECTED; echo "pwned';
+      execGitSeq([['add', '.'], ['commit', '-m', payload]], { cwd: dir }, (err) => {
+        expect(err).toBeNull();
+        // The injection side effect must NOT have happened, in the repo or cwd.
+        expect(fs.existsSync(path.join(dir, 'INJECTED'))).toBe(false);
+        expect(fs.existsSync(path.join(process.cwd(), 'INJECTED'))).toBe(false);
+        // And the commit subject is the exact literal payload.
+        execGit(['log', '-1', '--pretty=%s'], { cwd: dir }, (e2, stdout) => {
+          expect(e2).toBeNull();
+          expect(stdout.trim()).toBe(payload);
+          fs.rmSync(dir, { recursive: true, force: true });
+          done();
+        });
+      });
+    });
+  });
+
+  test('execGitSeq runs steps in order and returns each stdout', (done) => {
+    const dir = mkTmp();
+    initRepo(dir, () => {
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'a');
+      execGitSeq([['add', '.'], ['status', '--short']], { cwd: dir }, (err, outs) => {
+        expect(err).toBeNull();
+        expect(Array.isArray(outs)).toBe(true);
+        expect(outs).toHaveLength(2);
+        expect(outs[1]).toMatch(/a\.txt/); // status shows the staged file
+        fs.rmSync(dir, { recursive: true, force: true });
+        done();
+      });
+    });
+  });
+
+  test('execGitSeq aborts on the first failing step (mirrors shell &&)', (done) => {
+    const dir = mkTmp();
+    initRepo(dir, () => {
+      // `git commit` with nothing staged fails; the second step must not run.
+      execGitSeq([['commit', '-m', 'x'], ['tag', 'SHOULD_NOT_EXIST']], { cwd: dir }, (err) => {
+        expect(err).not.toBeNull();
+        execGit(['tag', '--list'], { cwd: dir }, (e2, stdout) => {
+          expect(stdout).not.toMatch(/SHOULD_NOT_EXIST/);
+          fs.rmSync(dir, { recursive: true, force: true });
+          done();
+        });
+      });
+    });
+  });
+
+  test('execGit passes a path argument literally (no glob/again no shell)', (done) => {
+    const dir = mkTmp();
+    initRepo(dir, () => {
+      // A filename containing shell metacharacters is added verbatim.
+      const weird = 'a b;$(touch NOPE).txt';
+      fs.writeFileSync(path.join(dir, weird), 'x');
+      execGit(['add', weird], { cwd: dir }, (err) => {
+        expect(err).toBeNull();
+        expect(fs.existsSync(path.join(dir, 'NOPE'))).toBe(false);
+        fs.rmSync(dir, { recursive: true, force: true });
+        done();
+      });
+    });
+  });
+
+  test('the (args, callback) overload works (options omitted)', (done) => {
+    execGit(['--version'], (err, stdout) => {
+      expect(err).toBeNull();
+      expect(stdout).toMatch(/git version/);
+      done();
+    });
+  });
+
+  test('execGitSeq (steps, callback) overload works (options omitted)', (done) => {
+    execGitSeq([['--version']], (err, outs) => {
+      expect(err).toBeNull();
+      expect(outs[0]).toMatch(/git version/);
+      done();
+    });
+  });
+
+  // Argument-injection guard (the residual class after de-shelling): a value
+  // beginning with '-' must be a positional, not a git option. `clone --`
+  // enforces that, so a `--upload-pack=` payload is treated as a repo name
+  // (clone fails) and never executed.
+  test('git clone -- treats a leading-dash argument as a repo, not an option', (done) => {
+    const dir = mkTmp();
+    const marker = path.join(dir, 'PWNED_CLONE');
+    execGit(['clone', '--', `--upload-pack=touch ${marker}`, path.join(dir, 'dest')], (err) => {
+      expect(err).not.toBeNull(); // no such repo -> clone fails
+      expect(fs.existsSync(marker)).toBe(false); // and nothing was executed
+      fs.rmSync(dir, { recursive: true, force: true });
+      done();
+    });
+  });
+
+  test('execGitSync returns stdout as a string', () => {
+    expect(execGitSync(['--version'])).toMatch(/git version/);
+  });
+
+  test('execGitP resolves with stdout', async () => {
+    await expect(execGitP(['--version'])).resolves.toMatch(/git version/);
+  });
+});
+
+describe('isHttpGitUrl (remote-URL argument guard)', () => {
+  test('accepts http(s) / ssh / scp-style git URLs', () => {
+    for (const u of [
+      'https://github.com/festion/homelab-gitops.git',
+      'http://internal/x/y.git',
+      'ssh://git@host:22/x/y.git',
+      'git@github.com:festion/x.git',
+    ]) {
+      expect(isHttpGitUrl(u)).toBe(true);
+    }
+  });
+
+  test('rejects option-injection, dangerous transports, and non-strings', () => {
+    for (const u of [
+      '--upload-pack=touch /tmp/x', // leading '-' → option injection
+      '-c',
+      'ext::sh -c "id"', // arbitrary-command transport
+      'file:///etc/passwd',
+      '', ' ', null, undefined, 42, {},
+    ]) {
+      expect(isHttpGitUrl(u)).toBe(false);
+    }
+  });
+});
+
+describe('safe-exec removeDir (no shell, replaces `rm -rf ${x}`)', () => {
+  test('recursively removes a directory tree', (done) => {
+    const dir = mkTmp();
+    fs.mkdirSync(path.join(dir, 'nested'));
+    fs.writeFileSync(path.join(dir, 'nested', 'f.txt'), 'x');
+    removeDir(dir, (err) => {
+      expect(err == null).toBe(true);
+      expect(fs.existsSync(dir)).toBe(false);
+      done();
+    });
+  });
+
+  test('does not throw on a missing path (force semantics)', (done) => {
+    removeDir(path.join(os.tmpdir(), 'safeexec-does-not-exist-12345'), (err) => {
+      expect(err == null).toBe(true);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Phase 3 of the repo security-audit pipeline (Vikunja #2162) — first remediation target

Remediates all **18 critical `js/command-line-injection`** CodeQL alerts on the gitops-audit-api. Every flagged site built a shell string from **request input** and handed it to `child_process.exec` (which spawns `/bin/sh`):

```js
// api/createApp.js /audit/commit — before
exec(`cd ${repoPath} && git add . && git commit -m "${message}"`, …)
```

A `message` / `repo` / `clone_url` like `"; rm -rf … "` or `$(...)` executed on prod (CT 123). Verified real (dashboard routes → these handlers), not false positives.

### Fix: run everything with no shell
New `api/lib/safe-exec.js`: `execGit` / `execGitSeq` (execFile `git`, argument arrays), `execGitSync`, `execGitP`, `removeDir` (`fs.rm`, replaces `rm -rf ${x}`), `isHttpGitUrl` (URL guard). Arguments are passed literally to `execve`, so a value can never be a command.

Converted **every** reachable site — createApp.js (9), github-mcp-manager.js (6), server-mcp.js (2), server-v2.js (1), email-notifications.js (1: `mail … < file` → `spawn('mail',[args])` + stdin pipe).

### Scope expanded during adversarial (Fable) review — same class, same attacker input
- **Argument injection:** a URL/recipient beginning with `-` is parsed as a git/mail **option** (`--upload-pack=…` → RCE-adjacent). Added `git clone --` end-of-options + `isHttpGitUrl` / recipient validation on clone / `remote set-url` / mail.
- **Two missed shell sites** interpolating a git **tag from a cloned (untrusted) repo** — `searchService.js` (`execSync`) and `repositoryCollector.js` (`exec`) → `execGitSync` / `execGitP` with a `refs/tags/` prefix (blocks shell **and** option parsing).
- Removed a now-dead `exec` import in `phase2-endpoints.js`.

### Tests
`tests/lib/safe-exec.test.js` — 13 jest cases proving metacharacter payloads are stored **literally** (no `INJECTED` file), `clone --` neutralises option injection, and `isHttpGitUrl` rejects `-…` / `ext::` / `file://`. Full api suite green: **Unit 117, Integration + WebSocket 30, 0 regressions.**

Static/internal commands (`df`, `git status`, `du`, the internal-date `git log --since`) are not attacker-controlled and are intentionally left unchanged.

> ⚠️ **Deploys to prod (CT 123) on merge.** Left for human review/merge — not auto-merged. `fs.rm` needs Node ≥14.14 (CT 123 runs Node 22, fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)