### PR TITLE
security(dashboard): encode fetch path segments in WikiAgent (SSRF, #2162)

### DIFF
--- a/dashboard/src/components/WikiAgent/SyncStatus.jsx
+++ b/dashboard/src/components/WikiAgent/SyncStatus.jsx
@@ -76,7 +76,7 @@ const SyncStatus = () => {
 
   const handleSyncAction = async (action) => {
     try {
-      const response = await fetch(`/api/wiki-agent/sync/${action}`, {
+      const response = await fetch(`/api/wiki-agent/sync/${encodeURIComponent(action)}`, {
         method: 'POST'
       });
 
@@ -90,7 +90,7 @@ const SyncStatus = () => {
 
   const handleConflictResolution = async (conflictId, resolution) => {
     try {
-      const response = await fetch(`/api/wiki-agent/sync/conflicts/${conflictId}/resolve`, {
+      const response = await fetch(`/api/wiki-agent/sync/conflicts/${encodeURIComponent(conflictId)}/resolve`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ resolution })

--- a/dashboard/src/components/WikiAgent/UploadQueue.jsx
+++ b/dashboard/src/components/WikiAgent/UploadQueue.jsx
@@ -66,9 +66,12 @@ const UploadQueue = () => {
 
   const handleQueueAction = async (action, itemId = null) => {
     try {
-      const endpoint = itemId 
-        ? `/api/wiki-agent/queue/${itemId}/${action}`
-        : `/api/wiki-agent/queue/${action}`;
+      // encodeURIComponent so a server-derived id/action can only ever be a
+      // single path segment — it cannot restructure the URL or make it absolute
+      // (request-forgery, CodeQL js/request-forgery).
+      const endpoint = itemId
+        ? `/api/wiki-agent/queue/${encodeURIComponent(itemId)}/${encodeURIComponent(action)}`
+        : `/api/wiki-agent/queue/${encodeURIComponent(action)}`;
       
       const response = await fetch(endpoint, { method: 'POST' });
       


### PR DESCRIPTION
## Phase 3 — the 2 SSRF criticals (Vikunja #2162)

Remediates the 2 critical **`js/request-forgery`** CodeQL alerts (the SSRF pair left after the command-injection PR #181).

`UploadQueue.jsx` and `SyncStatus.jsx` built `fetch()` URLs by interpolating **server-derived ids/actions** straight into the path:
```js
fetch(`/api/wiki-agent/queue/${itemId}/${action}`)
fetch(`/api/wiki-agent/sync/conflicts/${conflictId}/resolve`)
```
CodeQL tracks `itemId`/`conflictId` as tainted (they originate from fetched queue/conflict data). A value like `../../x` or an absolute URL could restructure the request path or send it cross-origin.

**Fix:** wrap each interpolated segment in `encodeURIComponent` — the CodeQL-recognized barrier that forces the value to a single path segment (can't restructure the URL or change host/scheme). Also encoded the same-file `sync/${action}` sibling for consistency.

**Verification:** dashboard `vite build` clean (3069 modules); CodeQL is the authoritative check for this class. No component test infra exists for these files (dashboard has zero WikiAgent component tests), so verification is via CodeQL + build.

> Frontend-only; the deploy ships the rebuilt dashboard. Not auto-merged.
>
> **Note:** 6 sibling interpolated fetches in *other* WikiAgent components (`WikiAgentOverview`, `BatchProcessor`, `AlertingSystem`, `ExportReports`, `ConfigurationPanel`) use the same pattern but are **not** CodeQL-flagged (their inputs aren't tracked as tainted) — a defense-in-depth follow-up, not a current finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)