### PR TITLE
security(api): fix SQL injection (metrics) + regex injection (search) — #2162 high backlog

### DIFF
--- a/api/lib/regex-safe.js
+++ b/api/lib/regex-safe.js
@@ -1,0 +1,16 @@
+/**
+ * Escape a string so it matches literally inside a RegExp (js/regex-injection,
+ * Vikunja #2162). Neutralizes user-supplied search terms before they are
+ * interpolated into `new RegExp(...)`, preventing both syntax errors from
+ * unbalanced metacharacters and ReDoS from attacker-crafted patterns.
+ *
+ * @param {*} value input to escape (non-strings are coerced to '')
+ * @returns {string} regex-literal-safe string
+ */
+function escapeRegExp(value) {
+  if (typeof value !== 'string') return '';
+  // Escape all characters with special meaning in a RegExp.
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { escapeRegExp };

--- a/api/lib/sql-identifiers.js
+++ b/api/lib/sql-identifiers.js
@@ -1,0 +1,49 @@
+/**
+ * SQL identifier allowlisting for the metrics store (js/sql-injection, Vikunja #2162).
+ *
+ * SQL identifiers (column names) and the ORDER BY direction keyword cannot be
+ * passed as bound parameters, so any caller-supplied value must be resolved
+ * against a fixed allowlist. Each helper returns a value taken FROM the constant
+ * allowlist — never the caller's string — which both guarantees safety and
+ * severs the taint flow CodeQL tracks.
+ */
+
+// Columns of the `metrics` table that are safe to ORDER BY.
+const ORDERABLE_COLUMNS = Object.freeze([
+  'timestamp',
+  'metric_type',
+  'entity_id',
+  'value',
+  'created_at',
+  'id',
+]);
+
+const DEFAULT_ORDER_COLUMN = 'timestamp';
+
+/**
+ * Resolve a requested ORDER BY column to a known-safe column name.
+ * @param {*} column caller-supplied column name
+ * @returns {string} an allowlisted column (defaults to `timestamp`)
+ */
+function safeOrderColumn(column) {
+  const idx = ORDERABLE_COLUMNS.indexOf(column);
+  // Return the constant from the allowlist, not the (possibly tainted) input.
+  return idx === -1 ? DEFAULT_ORDER_COLUMN : ORDERABLE_COLUMNS[idx];
+}
+
+/**
+ * Resolve a requested ORDER BY direction to a SQL keyword.
+ * @param {*} direction caller-supplied direction
+ * @returns {'ASC'|'DESC'} normalized keyword (defaults to `DESC`)
+ */
+function safeOrderDirection(direction) {
+  return typeof direction === 'string' && direction.trim().toUpperCase() === 'ASC'
+    ? 'ASC'
+    : 'DESC';
+}
+
+module.exports = {
+  ORDERABLE_COLUMNS,
+  safeOrderColumn,
+  safeOrderDirection,
+};

--- a/api/services/metrics/metricsStorage.js
+++ b/api/services/metrics/metricsStorage.js
@@ -13,6 +13,7 @@ const {
     AggregatedMetrics,
     MetricsQuery 
 } = require('../../models/metrics');
+const { safeOrderColumn, safeOrderDirection } = require('../../lib/sql-identifiers');
 
 class MetricsStorage {
     constructor(config = {}) {
@@ -435,16 +436,18 @@ class MetricsStorage {
             params.push(query.timeRange.to);
         }
 
-        // Add tag filters
+        // Add tag filters. The JSON path is bound as a parameter (SQLite accepts
+        // json_extract(X, ?)) so a hostile tag key cannot alter the SQL structure.
         for (const [key, value] of Object.entries(query.filters)) {
             if (key.startsWith('tags.')) {
                 const tagKey = key.replace('tags.', '');
-                sql += ` AND JSON_EXTRACT(tags, '$.${tagKey}') = ?`;
-                params.push(value);
+                sql += ' AND JSON_EXTRACT(tags, ?) = ?';
+                params.push(`$.${tagKey}`, value);
             }
         }
 
-        sql += ` ORDER BY ${query.orderBy} ${query.orderDirection}`;
+        // ORDER BY column/direction cannot be bound; resolve against an allowlist.
+        sql += ` ORDER BY ${safeOrderColumn(query.orderBy)} ${safeOrderDirection(query.orderDirection)}`;
         
         if (query.limit) {
             sql += ' LIMIT ?';

--- a/api/services/searchService.js
+++ b/api/services/searchService.js
@@ -6,6 +6,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const { performance } = require('perf_hooks');
+const { escapeRegExp } = require('../lib/regex-safe');
 
 class SearchService {
   constructor() {
@@ -618,7 +619,8 @@ class SearchService {
     const normalizedQuery = query.toLowerCase();
     const highlightTag = (text, term) => {
       if (!text) return text;
-      const regex = new RegExp(`(${term})`, 'gi');
+      // Escape the term so user input matches literally (prevents regex injection/ReDoS).
+      const regex = new RegExp(`(${escapeRegExp(term)})`, 'gi');
       return text.replace(regex, '<mark>$1</mark>');
     };
 

--- a/api/tests/lib/regex-safe.test.js
+++ b/api/tests/lib/regex-safe.test.js
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for escapeRegExp (js/regex-injection remediation, Vikunja #2162).
+ *
+ * User-supplied search terms are interpolated into `new RegExp(...)` for
+ * highlighting. Without escaping, a term containing regex metacharacters either
+ * throws (unbalanced group) or enables ReDoS. escapeRegExp turns any string into
+ * a literal-match pattern.
+ */
+const { escapeRegExp } = require('../../lib/regex-safe');
+
+describe('escapeRegExp', () => {
+  test('escapes all regex metacharacters', () => {
+    expect(escapeRegExp('a.b*c+d?')).toBe('a\\.b\\*c\\+d\\?');
+    expect(escapeRegExp('(group)')).toBe('\\(group\\)');
+    expect(escapeRegExp('[set]{n}')).toBe('\\[set\\]\\{n\\}');
+    expect(escapeRegExp('^start|end$')).toBe('\\^start\\|end\\$');
+    expect(escapeRegExp('back\\slash')).toBe('back\\\\slash');
+  });
+
+  test('leaves plain text unchanged', () => {
+    expect(escapeRegExp('homelab-gitops')).toBe('homelab-gitops');
+  });
+
+  test('a term with an unbalanced group no longer throws when used in RegExp', () => {
+    const term = '(unclosed';
+    const build = () => new RegExp(`(${escapeRegExp(term)})`, 'gi');
+    expect(build).not.toThrow();
+    const re = build();
+    expect('x(unclosed y'.replace(re, '<mark>$1</mark>')).toBe('x<mark>(unclosed</mark> y');
+  });
+
+  test('a metacharacter term matches literally, not as a pattern', () => {
+    const re = new RegExp(`(${escapeRegExp('.')})`, 'gi');
+    // Should highlight only literal dots, not every character.
+    expect('a.b'.replace(re, '[$1]')).toBe('a[.]b');
+  });
+});

--- a/api/tests/lib/sql-identifiers.test.js
+++ b/api/tests/lib/sql-identifiers.test.js
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for SQL identifier allowlisting (js/sql-injection remediation, Vikunja #2162).
+ *
+ * ORDER BY column and direction cannot be bound as SQL parameters, so they must
+ * be resolved against a fixed allowlist. Returning a constant from the allowlist
+ * (never the caller's string) both enforces safety and breaks CodeQL taint flow.
+ */
+const {
+  safeOrderColumn,
+  safeOrderDirection,
+} = require('../../lib/sql-identifiers');
+
+describe('safeOrderColumn', () => {
+  test('returns an allowlisted column', () => {
+    expect(safeOrderColumn('metric_type')).toBe('metric_type');
+    expect(safeOrderColumn('timestamp')).toBe('timestamp');
+    expect(safeOrderColumn('value')).toBe('value');
+  });
+
+  test('falls back to timestamp for an unknown column', () => {
+    expect(safeOrderColumn('not_a_column')).toBe('timestamp');
+  });
+
+  test('falls back to timestamp for an injection attempt', () => {
+    expect(safeOrderColumn('timestamp; DROP TABLE metrics;--')).toBe('timestamp');
+    expect(safeOrderColumn('(SELECT 1)')).toBe('timestamp');
+  });
+
+  test('falls back to timestamp for non-string input', () => {
+    expect(safeOrderColumn(undefined)).toBe('timestamp');
+    expect(safeOrderColumn(null)).toBe('timestamp');
+    expect(safeOrderColumn(42)).toBe('timestamp');
+  });
+});
+
+describe('safeOrderDirection', () => {
+  test('normalizes ASC in any case', () => {
+    expect(safeOrderDirection('asc')).toBe('ASC');
+    expect(safeOrderDirection('ASC')).toBe('ASC');
+    expect(safeOrderDirection('Asc')).toBe('ASC');
+  });
+
+  test('everything else resolves to DESC', () => {
+    expect(safeOrderDirection('desc')).toBe('DESC');
+    expect(safeOrderDirection('DESC')).toBe('DESC');
+    expect(safeOrderDirection('ASC; DROP TABLE metrics')).toBe('DESC');
+    expect(safeOrderDirection(undefined)).toBe('DESC');
+    expect(safeOrderDirection(null)).toBe('DESC');
+  });
+});

--- a/api/tests/services/metricsStorage-buildsql.test.js
+++ b/api/tests/services/metricsStorage-buildsql.test.js
@@ -1,0 +1,65 @@
+/**
+ * Integration tests for MetricsStorage.buildSQL SQL-injection remediation
+ * (js/sql-injection, Vikunja #2162).
+ *
+ * buildSQL is pure (no DB handle needed) — it turns a MetricsQuery into a
+ * parameterized { sql, params }. These tests assert that attacker-controlled
+ * ORDER BY / tag-key values cannot alter the SQL structure.
+ */
+const MetricsStorage = require('../../services/metrics/metricsStorage');
+const { MetricsQuery } = require('../../models/metrics');
+
+function makeQuery(overrides = {}) {
+  const q = new MetricsQuery();
+  Object.assign(q, overrides);
+  return q;
+}
+
+describe('MetricsStorage.buildSQL — ORDER BY injection', () => {
+  const storage = new MetricsStorage();
+
+  test('a valid orderBy column is emitted', () => {
+    const { sql } = storage.buildSQL(makeQuery({ orderBy: 'metric_type', orderDirection: 'ASC' }));
+    expect(sql).toContain('ORDER BY metric_type ASC');
+  });
+
+  test('an injected orderBy column is neutralized to timestamp', () => {
+    const { sql } = storage.buildSQL(
+      makeQuery({ orderBy: 'timestamp; DROP TABLE metrics;--', orderDirection: 'DESC' })
+    );
+    expect(sql).not.toContain('DROP TABLE');
+    expect(sql).toContain('ORDER BY timestamp DESC');
+  });
+
+  test('an injected orderDirection is neutralized to a keyword', () => {
+    const { sql } = storage.buildSQL(
+      makeQuery({ orderBy: 'timestamp', orderDirection: 'ASC; DELETE FROM metrics' })
+    );
+    expect(sql).not.toContain('DELETE');
+    expect(sql).toMatch(/ORDER BY timestamp (ASC|DESC)\b/);
+  });
+});
+
+describe('MetricsStorage.buildSQL — tag-key injection', () => {
+  const storage = new MetricsStorage();
+
+  test('a tag filter binds the JSON path as a parameter, not string-interpolated', () => {
+    const q = makeQuery();
+    q.filters = { "tags.env') = 1 OR JSON_EXTRACT(tags, '$.x": 'prod' };
+    const { sql, params } = storage.buildSQL(q);
+    // The malicious key must not appear inline in the SQL text.
+    expect(sql).not.toContain('OR JSON_EXTRACT');
+    // Path is a bound parameter of the form $.<key>.
+    expect(sql).toContain('JSON_EXTRACT(tags, ?)');
+    expect(params).toContain("$.env') = 1 OR JSON_EXTRACT(tags, '$.x");
+  });
+
+  test('a normal tag filter still works', () => {
+    const q = makeQuery();
+    q.filters = { 'tags.environment': 'prod' };
+    const { sql, params } = storage.buildSQL(q);
+    expect(sql).toContain('JSON_EXTRACT(tags, ?) = ?');
+    expect(params).toContain('$.environment');
+    expect(params).toContain('prod');
+  });
+});


### PR DESCRIPTION
## Summary
First PR of the **high-severity CodeQL backlog** (Vikunja #2162, Phase 3). Fixes the two genuinely-exploitable high findings in the API runtime; verified with TDD + runtime proof. **Merging deploys to prod CT123** — left for human review.

## Findings fixed
| Rule | Location | Fix |
|---|---|---|
| `js/sql-injection` | `metricsStorage.buildSQL` (`ORDER BY ${orderBy} ${orderDirection}`, `JSON_EXTRACT(tags, '$.${tagKey}')`) | ORDER BY column/direction → fixed **allowlist** returning constants (also severs taint); JSON path **bound as a parameter** (`json_extract(X, ?)`, verified to execute) |
| `js/regex-injection` | `searchService.applyHighlighting` (`new RegExp(\`(${term})\`)`) | user term `escapeRegExp`'d → literal match (kills throw-on-`(` + ReDoS) |

## New code
- `api/lib/sql-identifiers.js` — `safeOrderColumn` / `safeOrderDirection` (allowlist for the `metrics` table)
- `api/lib/regex-safe.js` — `escapeRegExp`
- Tests: `tests/lib/sql-identifiers.test.js`, `tests/lib/regex-safe.test.js`, `tests/services/metricsStorage-buildsql.test.js` (injection payloads proven neutralized)

## Verification
- New tests: watched them fail first (buildSQL RED literally emitted `ORDER BY timestamp; DROP TABLE metrics;--`), then pass. 15 new + injection integration cases green.
- **Full API suite: 168/168, 0 regressions.**
- Proved SQLite executes `JSON_EXTRACT(tags, ?)` with a bound `$.<key>` path (not just string-shaped).
- CodeQL is the oracle for RED→GREEN — see the code-scanning check on this PR.

## Out of scope (noted)
- Two other `new RegExp` sites (`webhook/automatedSetup.js:250`, `middleware/enhanced-security.js:72`) are **config-driven and NOT CodeQL-flagged** — left as-is.
- Remaining high backlog (tainted-format-string ×45, missing-rate-limiting ×60, sanitizer cluster ×~15) and the Trivy vendored-venv/container CVEs follow as separate PRs.