### PR TITLE
security(api): fix tainted-format-string in logs (45 sites) — #2162 high backlog

### DIFF
--- a/api/github-mcp-manager.js
+++ b/api/github-mcp-manager.js
@@ -208,7 +208,7 @@ class GitHubMCPManager {
             throw new Error('No MCP servers available');
             
         } catch (error) {
-            console.error(`❌ GitHub MCP clone failed for ${repoName}:`, error);
+            console.error('❌ GitHub MCP clone failed for %s:', sanitizeForLog(repoName), error);
             return this.cloneRepositoryFallback(repoName, cloneUrl, destPath);
         }
     }
@@ -225,7 +225,7 @@ class GitHubMCPManager {
             }
             execGit(['clone', '--', cloneUrl, destPath], (err, stdout, stderr) => {
                 if (err) {
-                    console.error(`❌ Git clone failed for ${repoName}:`, stderr);
+                    console.error('❌ Git clone failed for %s:', sanitizeForLog(repoName), stderr);
                     reject(new Error(`Failed to clone ${repoName}: ${stderr}`));
                 } else {
                     console.log(`✅ Successfully cloned ${repoName}`);
@@ -297,7 +297,7 @@ class GitHubMCPManager {
             throw new Error('No MCP servers available');
             
         } catch (error) {
-            console.error(`❌ GitHub MCP commit failed for ${repoName}:`, error);
+            console.error('❌ GitHub MCP commit failed for %s:', sanitizeForLog(repoName), error);
             return this.commitChangesFallback(repoName, repoPath, message);
         }
     }
@@ -349,7 +349,7 @@ class GitHubMCPManager {
             // TODO: Use Serena to orchestrate GitHub MCP operations
             throw new Error('GitHub MCP not yet implemented - using fallback');
         } catch (error) {
-            console.error(`❌ GitHub MCP remote update failed for ${repoName}:`, error);
+            console.error('❌ GitHub MCP remote update failed for %s:', sanitizeForLog(repoName), error);
             return this.updateRemoteUrlFallback(repoName, repoPath, newUrl);
         }
     }
@@ -366,7 +366,7 @@ class GitHubMCPManager {
             }
             execGit(['remote', 'set-url', 'origin', newUrl], { cwd: repoPath }, (err, stdout, stderr) => {
                 if (err) {
-                    console.error(`❌ Git remote update failed for ${repoName}:`, stderr);
+                    console.error('❌ Git remote update failed for %s:', sanitizeForLog(repoName), stderr);
                     reject(new Error(`Failed to fix remote URL: ${stderr}`));
                 } else {
                     console.log(`✅ Successfully updated remote URL for ${repoName}`);
@@ -399,7 +399,7 @@ class GitHubMCPManager {
             // TODO: Use Serena to orchestrate GitHub MCP operations
             throw new Error('GitHub MCP not yet implemented - using fallback');
         } catch (error) {
-            console.error(`❌ GitHub MCP get remote failed for ${repoName}:`, error);
+            console.error('❌ GitHub MCP get remote failed for %s:', sanitizeForLog(repoName), error);
             return this.getRemoteUrlFallback(repoName, repoPath);
         }
     }
@@ -413,7 +413,7 @@ class GitHubMCPManager {
             
             execGit(['remote', 'get-url', 'origin'], { cwd: repoPath }, (err, stdout, stderr) => {
                 if (err) {
-                    console.error(`❌ Git get remote failed for ${repoName}:`, stderr);
+                    console.error('❌ Git get remote failed for %s:', sanitizeForLog(repoName), stderr);
                     reject(new Error('Failed to get remote URL'));
                 } else {
                     console.log(`✅ Successfully retrieved remote URL for ${repoName}`);
@@ -446,7 +446,7 @@ class GitHubMCPManager {
             // TODO: Use Serena to orchestrate GitHub MCP operations
             throw new Error('GitHub MCP not yet implemented - using fallback');
         } catch (error) {
-            console.error(`❌ GitHub MCP discard failed for ${repoName}:`, error);
+            console.error('❌ GitHub MCP discard failed for %s:', sanitizeForLog(repoName), error);
             return this.discardChangesFallback(repoName, repoPath);
         }
     }
@@ -497,7 +497,7 @@ class GitHubMCPManager {
             // TODO: Use Serena to orchestrate GitHub MCP operations
             throw new Error('GitHub MCP not yet implemented - using fallback');
         } catch (error) {
-            console.error(`❌ GitHub MCP diff failed for ${repoName}:`, error);
+            console.error('❌ GitHub MCP diff failed for %s:', sanitizeForLog(repoName), error);
             return this.getRepositoryDiffFallback(repoName, repoPath);
         }
     }
@@ -618,7 +618,7 @@ class GitHubMCPManager {
             return [];
             
         } catch (error) {
-            console.error(`❌ Failed to get modified files in ${repoPath}:`, error);
+            console.error('❌ Failed to get modified files in %s:', sanitizeForLog(repoPath), error);
             return [];
         }
     }

--- a/api/phase2-endpoints.js
+++ b/api/phase2-endpoints.js
@@ -2,6 +2,7 @@
 // Extends the main API server with Phase 2 DevOps platform features
 
 const express = require('express');
+const { sanitizeForLog } = require('./lib/safe-exec');
 const fs = require('fs').promises;
 const path = require('path');
 const { randomUUID } = require('node:crypto');
@@ -1783,7 +1784,7 @@ phase2Router.get('/pipelines/history/:repo', async (req, res) => {
     
     res.json(result);
   } catch (error) {
-    console.error(`Error getting pipeline history for ${req.params.repo}:`, error);
+    console.error('Error getting pipeline history for %s:', sanitizeForLog(req.params.repo), error);
     res.status(500).json({ 
       error: 'Failed to get pipeline history', 
       details: error.message 
@@ -2303,7 +2304,7 @@ phase2Router.get('/compliance/repository/:repo', async (req, res) => {
     if (error && error.code === 'REPO_NOT_FOUND') {
       return res.status(404).json({ error: error.message });
     }
-    console.error(`Error getting repository compliance for ${req.params.repo}:`, error);
+    console.error('Error getting repository compliance for %s:', sanitizeForLog(req.params.repo), error);
     res.status(500).json({
       error: 'Failed to get repository compliance',
       details: error.message

--- a/api/routes/metrics.js
+++ b/api/routes/metrics.js
@@ -6,6 +6,7 @@
  */
 
 const express = require('express');
+const { sanitizeForLog } = require('../lib/safe-exec');
 const { MetricsQuery } = require('../models/metrics');
 
 class MetricsRoutes {
@@ -143,7 +144,7 @@ class MetricsRoutes {
                 timestamp: new Date().toISOString()
             });
         } catch (error) {
-            console.error(`Error getting repository metrics for ${req.params.repo}:`, error);
+            console.error('Error getting repository metrics for %s:', sanitizeForLog(req.params.repo), error);
             res.status(500).json({
                 success: false,
                 error: 'Failed to get repository metrics',

--- a/api/routes/webhooks.js
+++ b/api/routes/webhooks.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { sanitizeForLog } = require('../lib/safe-exec');
 const router = express.Router();
 const WebhookConfigService = require('../services/github/webhookConfig');
 const EnhancedWebhookHandler = require('../services/webhook/enhancedWebhookHandler');
@@ -124,7 +125,7 @@ router.post('/setup/:owner/:repo', async (req, res) => {
       message: `Webhook configured successfully for ${owner}/${repo}`
     });
   } catch (error) {
-    console.error(`Error setting up webhook for ${req.params.owner}/${req.params.repo}:`, error);
+    console.error('Error setting up webhook for %s/%s:', sanitizeForLog(req.params.owner), sanitizeForLog(req.params.repo), error);
     res.status(500).json({ 
       error: error.message,
       repository: `${req.params.owner}/${req.params.repo}`
@@ -160,7 +161,7 @@ router.delete('/remove/:owner/:repo', async (req, res) => {
       });
     }
   } catch (error) {
-    console.error(`Error removing webhook from ${req.params.owner}/${req.params.repo}:`, error);
+    console.error('Error removing webhook from %s/%s:', sanitizeForLog(req.params.owner), sanitizeForLog(req.params.repo), error);
     res.status(500).json({ 
       error: error.message,
       repository: `${req.params.owner}/${req.params.repo}`
@@ -299,7 +300,7 @@ router.get('/repository/:owner/:repo/status', async (req, res) => {
       }
     });
   } catch (error) {
-    console.error(`Error getting webhook status for ${req.params.owner}/${req.params.repo}:`, error);
+    console.error('Error getting webhook status for %s/%s:', sanitizeForLog(req.params.owner), sanitizeForLog(req.params.repo), error);
     res.status(500).json({ 
       error: error.message,
       repository: `${req.params.owner}/${req.params.repo}`
@@ -338,7 +339,7 @@ router.post('/test/:owner/:repo', async (req, res) => {
       });
     }
   } catch (error) {
-    console.error(`Error testing webhook for ${req.params.owner}/${req.params.repo}:`, error);
+    console.error('Error testing webhook for %s/%s:', sanitizeForLog(req.params.owner), sanitizeForLog(req.params.repo), error);
     res.status(500).json({ 
       error: error.message,
       repository: `${req.params.owner}/${req.params.repo}`

--- a/api/serena-orchestrator.js
+++ b/api/serena-orchestrator.js
@@ -5,6 +5,8 @@
  * SerenaOrchestrator coordinates MCP operations across multiple servers
  * Following the MCP integration guidelines where Serena marshalls all other MCP servers
  */
+const { sanitizeForLog } = require('./lib/safe-exec');
+
 class SerenaOrchestrator {
     constructor(mcpServers) {
         this.githubMCP = mcpServers.github || null;
@@ -62,7 +64,7 @@ class SerenaOrchestrator {
             };
 
         } catch (error) {
-            console.error(`❌ Serena orchestration failed for clone ${repoName}:`, error);
+            console.error('❌ Serena orchestration failed for clone %s:', sanitizeForLog(repoName), error);
             
             // Log failure through Serena if available
             if (this.serenaMCP) {
@@ -136,7 +138,7 @@ class SerenaOrchestrator {
             };
 
         } catch (error) {
-            console.error(`❌ Serena orchestration failed for commit ${repoName}:`, error);
+            console.error('❌ Serena orchestration failed for commit %s:', sanitizeForLog(repoName), error);
             
             // Log failure through Serena if available
             if (this.serenaMCP) {

--- a/api/server-mcp.js
+++ b/api/server-mcp.js
@@ -8,6 +8,7 @@
  */
 
 const express = require('express');
+const { sanitizeForLog } = require('./lib/safe-exec');
 const fs = require('fs');
 const path = require('path');
 const { removeDir, resolveWithin } = require('./lib/safe-exec');
@@ -446,7 +447,7 @@ app.post('/audit/clone', async (req, res) => {
     
     res.json(result);
   } catch (error) {
-    console.error(`❌ Clone failed for ${repo}:`, error);
+    console.error('❌ Clone failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: `Failed to clone ${repo}: ${error.message}` });
   }
 });
@@ -463,7 +464,7 @@ app.post('/audit/delete', (req, res) => {
   console.log(`🗑️  Deleting extra repository: ${repo}`);
   removeDir(target, async (err) => {
     if (err) {
-      console.error(`❌ Delete failed for ${repo}:`, err);
+      console.error('❌ Delete failed for %s:', sanitizeForLog(repo), err);
       return res.status(500).json({ error: `Failed to delete ${repo}` });
     }
     
@@ -513,7 +514,7 @@ app.post('/audit/commit', async (req, res) => {
     
     res.json(result);
   } catch (error) {
-    console.error(`❌ Commit failed for ${repo}:`, error);
+    console.error('❌ Commit failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: 'Commit failed', details: error.message });
   }
 });
@@ -550,7 +551,7 @@ if (isDev) {
       
       res.json(result);
     } catch (error) {
-      console.error(`❌ Remote URL fix failed for ${repo}:`, error);
+      console.error('❌ Remote URL fix failed for %s:', sanitizeForLog(repo), error);
       res.status(500).json({ error: 'Failed to fix remote URL', details: error.message });
     }
   });
@@ -579,7 +580,7 @@ if (isDev) {
         mismatch: currentUrl !== expectedUrl,
       });
     } catch (error) {
-      console.error(`❌ Mismatch check failed for ${repo}:`, error);
+      console.error('❌ Mismatch check failed for %s:', sanitizeForLog(repo), error);
       res.status(500).json({ error: 'Failed to get remote URL' });
     }
   });
@@ -638,7 +639,7 @@ if (isDev) {
         
         console.log(`✅ Batch ${operation} completed for ${repo}`);
       } catch (error) {
-        console.error(`❌ Batch ${operation} failed for ${repo}:`, error);
+        console.error('❌ Batch %s failed for %s:', sanitizeForLog(operation), sanitizeForLog(repo), error);
         results.push({
           repo,
           success: false,
@@ -681,7 +682,7 @@ app.post('/audit/discard', async (req, res) => {
     
     res.json(result);
   } catch (error) {
-    console.error(`❌ Discard failed for ${repo}:`, error);
+    console.error('❌ Discard failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: 'Discard failed', details: error.message });
   }
 });
@@ -703,7 +704,7 @@ app.get('/audit/diff/:repo', async (req, res) => {
     
     res.json({ repo, diff: result.diff });
   } catch (error) {
-    console.error(`❌ Diff failed for ${repo}:`, error);
+    console.error('❌ Diff failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: 'Diff failed', details: error.message });
   }
 });

--- a/api/server-v2.js
+++ b/api/server-v2.js
@@ -8,6 +8,7 @@
  */
 
 const express = require('express');
+const { sanitizeForLog } = require('./lib/safe-exec');
 const fs = require('fs');
 const path = require('path');
 const { removeDir, resolveWithin } = require('./lib/safe-exec');
@@ -148,7 +149,7 @@ app.post('/audit/clone', async (req, res) => {
     
     res.json(result);
   } catch (error) {
-    console.error(`❌ Clone failed for ${repo}:`, error);
+    console.error('❌ Clone failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: `Failed to clone ${repo}: ${error.message}` });
   }
 });
@@ -165,7 +166,7 @@ app.post('/audit/delete', (req, res) => {
   console.log(`🗑️  Deleting extra repository: ${repo}`);
   removeDir(target, async (err) => {
     if (err) {
-      console.error(`❌ Delete failed for ${repo}:`, err);
+      console.error('❌ Delete failed for %s:', sanitizeForLog(repo), err);
       return res.status(500).json({ error: `Failed to delete ${repo}` });
     }
     
@@ -191,7 +192,7 @@ app.post('/audit/commit', async (req, res) => {
     const result = await githubMCP.commitChanges(repo, repoPath, commitMessage);
     res.json(result);
   } catch (error) {
-    console.error(`❌ Commit failed for ${repo}:`, error);
+    console.error('❌ Commit failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: 'Commit failed', details: error.message });
   }
 });
@@ -212,7 +213,7 @@ app.post('/audit/discard', async (req, res) => {
     const result = await githubMCP.discardChanges(repo, repoPath);
     res.json(result);
   } catch (error) {
-    console.error(`❌ Discard failed for ${repo}:`, error);
+    console.error('❌ Discard failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: 'Discard failed', details: error.message });
   }
 });
@@ -234,7 +235,7 @@ app.get('/audit/diff/:repo', async (req, res) => {
     
     res.json({ repo, diff: result.diff });
   } catch (error) {
-    console.error(`❌ Diff failed for ${repo}:`, error);
+    console.error('❌ Diff failed for %s:', sanitizeForLog(repo), error);
     res.status(500).json({ error: 'Diff failed', details: error.message });
   }
 });

--- a/api/services/compliance/complianceService.js
+++ b/api/services/compliance/complianceService.js
@@ -677,7 +677,7 @@ class ComplianceService extends EventEmitter {
         });
 
       } catch (error) {
-        console.error(`Error applying template ${templateName} to ${repository}:`, error);
+        console.error('Error applying template %s to %s:', sanitizeForLog(templateName), sanitizeForLog(repository), error);
         
         results.push({
           template: templateName,

--- a/api/services/compliance/templateEngine.js
+++ b/api/services/compliance/templateEngine.js
@@ -339,7 +339,7 @@ class TemplateEngine {
       };
 
     } catch (error) {
-      console.error(`Error applying template ${templateName}:`, error);
+      console.error('Error applying template %s:', sanitizeForLog(templateName), error);
       throw error;
     }
   }

--- a/api/services/github/webhookConfig.js
+++ b/api/services/github/webhookConfig.js
@@ -1,4 +1,5 @@
 const { Octokit } = require('@octokit/rest');
+const { sanitizeForLog } = require('../../lib/safe-exec');
 const crypto = require('crypto');
 
 class WebhookConfigService {
@@ -63,7 +64,7 @@ class WebhookConfigService {
       console.log(`✅ Webhook created successfully for ${owner}/${repo}`);
       return webhook.data;
     } catch (error) {
-      console.error(`Failed to setup webhook for ${owner}/${repo}:`, error.message);
+      console.error('Failed to setup webhook for %s/%s:', sanitizeForLog(owner), sanitizeForLog(repo), error.message);
       
       // Handle specific error cases
       if (error.status === 404) {
@@ -140,7 +141,7 @@ class WebhookConfigService {
       console.log(`No webhook found for ${owner}/${repo}`);
       return false;
     } catch (error) {
-      console.error(`Failed to remove webhook for ${owner}/${repo}:`, error.message);
+      console.error('Failed to remove webhook for %s/%s:', sanitizeForLog(owner), sanitizeForLog(repo), error.message);
       throw error;
     }
   }
@@ -314,7 +315,7 @@ class WebhookConfigService {
         }
       };
     } catch (error) {
-      console.error(`Failed to get webhook status for ${owner}/${repo}:`, error.message);
+      console.error('Failed to get webhook status for %s/%s:', sanitizeForLog(owner), sanitizeForLog(repo), error.message);
       return {
         configured: false,
         webhook: null,

--- a/api/services/pipeline/pipelineService.js
+++ b/api/services/pipeline/pipelineService.js
@@ -21,6 +21,7 @@
  */
 
 const EventEmitter = require('events');
+const { sanitizeForLog } = require('../../lib/safe-exec');
 
 const REPO_METRICS_FIELDS = [
     'total',
@@ -89,7 +90,7 @@ class PipelineService extends EventEmitter {
                         });
                     }
                 } catch (error) {
-                    console.error(`Error fetching pipeline status for ${repository}:`, error);
+                    console.error('Error fetching pipeline status for %s:', sanitizeForLog(repository), error);
                     // Continue with other repositories
                 }
             }
@@ -175,7 +176,7 @@ class PipelineService extends EventEmitter {
                 }
             };
         } catch (error) {
-            console.error(`Error getting pipeline history for ${repository}:`, error);
+            console.error('Error getting pipeline history for %s:', sanitizeForLog(repository), error);
             throw new Error(`Failed to get pipeline history: ${error.message}`);
         }
     }
@@ -227,7 +228,7 @@ class PipelineService extends EventEmitter {
                 timestamp: new Date().toISOString()
             };
         } catch (error) {
-            console.error(`Error triggering pipeline for ${repository}:`, error);
+            console.error('Error triggering pipeline for %s:', sanitizeForLog(repository), error);
             throw new Error(`Failed to trigger pipeline: ${error.message}`);
         }
     }

--- a/api/services/webhook/enhancedWebhookHandler.js
+++ b/api/services/webhook/enhancedWebhookHandler.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { sanitizeForLog } = require('../../lib/safe-exec');
 const { EventEmitter } = require('events');
 const WebhookConfigService = require('../github/webhookConfig');
 const { createLogger } = require('../../utils/logger');
@@ -739,7 +740,7 @@ class EnhancedWebhookHandler extends EventEmitter {
       );
       console.log(`✅ Webhook setup complete for ${repository.full_name}`);
     } catch (error) {
-      console.error(`Failed to setup webhook for ${repository.full_name}:`, error);
+      console.error('Failed to setup webhook for %s:', sanitizeForLog(repository.full_name), error);
     }
   }
 
@@ -917,7 +918,7 @@ class EnhancedWebhookHandler extends EventEmitter {
       
       return result;
     } catch (error) {
-      console.error(`Repository dispatch handling failed for ${repository.full_name}:`, error);
+      console.error('Repository dispatch handling failed for %s:', sanitizeForLog(repository.full_name), error);
       
       // Emit deployment failed event
       this.emit('deployment_failed', {

--- a/api/utils/security-validator.js
+++ b/api/utils/security-validator.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { sanitizeForLog } = require('../lib/safe-exec');
 const { ConfigManager } = require('../config/utils/config-manager');
 
 /**
@@ -240,7 +241,7 @@ class SecurityValidator {
       // Check if IP is in the subnet
       return (ipInt & subnetMask) === (networkInt & subnetMask);
     } catch (error) {
-      console.error(`Error checking IP range for ${ip} in ${range}:`, error);
+      console.error('Error checking IP range for %s in %s:', sanitizeForLog(ip), sanitizeForLog(range), error);
       return false;
     }
   }

--- a/api/wiki-agent-manager.js
+++ b/api/wiki-agent-manager.js
@@ -14,6 +14,7 @@
  */
 
 const fs = require('fs');
+const { sanitizeForLog } = require('./lib/safe-exec');
 const path = require('path');
 const crypto = require('crypto');
 const sqlite3 = require('sqlite3').verbose();
@@ -709,7 +710,7 @@ class WikiAgentManager {
       }
       
     } catch (error) {
-      console.error(`❌ Failed to upload document ${documentId}:`, error);
+      console.error('❌ Failed to upload document %s:', sanitizeForLog(documentId), error);
       
       // Update document status to 'failed'
       await this.runQuery(`

--- a/upload-docs-to-wiki.js
+++ b/upload-docs-to-wiki.js
@@ -19,6 +19,7 @@
  */
 
 const fs = require('fs');
+const { sanitizeForLog } = require('./api/lib/safe-exec');
 const path = require('path');
 const crypto = require('crypto');
 const { EventEmitter } = require('events');
@@ -154,7 +155,7 @@ class WikiJSUploadManager extends EventEmitter {
       
       return uploadJob;
     } catch (error) {
-      console.error(`❌ Failed to add ${filePath} to queue:`, error.message);
+      console.error('❌ Failed to add %s to queue:', sanitizeForLog(filePath), error.message);
       this.emit('validation_error', { filePath, error });
       throw error;
     }


### PR DESCRIPTION
## Summary
PR 2 of the **high-severity CodeQL backlog** (Vikunja #2162, Phase 3). Clears all **45 `js/tainted-format-string`** high alerts. **Merging deploys to prod CT123** — left for your review.

## The finding
Request/repo-derived values were interpolated into the **format-string argument** of `console.error` via template literals:
```js
console.error(`Error setting up webhook for ${req.params.owner}/${req.params.repo}:`, error);
```
A value containing `%s`/`%d`/control chars is interpreted as a format directive → log forging / format-string injection.

## The fix (uniform, mechanical)
Pass the tainted value as a `%s` **argument** through `sanitizeForLog()` (strips control chars, caps length) — the exact helper the Phase-3 command-injection PR added (`api/lib/safe-exec.js`):
```js
console.error('Error setting up webhook for %s/%s:', sanitizeForLog(req.params.owner), sanitizeForLog(req.params.repo), error);
```
- 45 sites across 15 files. `sanitizeForLog` imported into 11 files (3 already had it; `templateEngine.js` defines its own).

## Verification
- **Full API suite: 168/168, 0 regressions.**
- `node --check` + require-path resolution verified on all 15 changed files.
- CodeQL is the oracle — see the code-scanning check on this PR (expect the 45 to clear).

## Out of scope (noted)
- Sibling `console.error` interpolations that CodeQL did **not** flag (`${name}`, `${interval}`, `${run.id}` — internal/config sources, not request-tainted) left as-is.
- Two `server-mcp.js`/`server-v2.js` are unreferenced legacy but were fixed too (clears their alerts; no runtime risk).