### PR TITLE
perf(context): drop the learnings @-import (~2k tokens/session)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,13 @@ The dashboard provides:
    - Check logs for connection errors
 
 
-## Learnings KB
+## Recall project knowledge
 
-@.claude/learnings.md
+The learnings base for this repo (4 KB) is **not** preloaded — it used to be
+`@`-imported, which expanded ~2k tokens into every session. Search it instead:
+
+```bash
+memory-search "<what you're about to change>" --project homelab-gitops
+```
+
+Query it before changing a route, a deploy path, or anything CodeQL has flagged.


### PR DESCRIPTION
Applies Anthropic's Claude 5 context guidance (progressive disclosure; under
~200 lines per `CLAUDE.md`; `@`-imports are **inlined at launch** and do not
save context).

**Nothing is deleted.** Every learnings file stays on disk, byte-for-byte, and
stays fully searchable via `memory-search` (local ChromaDB + embeddings, zero
API tokens) — which already indexes indexes *and* archives, per project. The
change is only about what is force-loaded into every session versus what is
recalled on demand.

Where an import was dropped, `CLAUDE.md` gains an explicit pointer telling the
next session to search, plus — where the repo has irreversible-consequence
rules — a short consequence-filtered "Non-negotiables" block so a safety rule is
never something you meet only *after* deciding to go looking for it.

Part of a cross-repo pass on branch `context/claude5-trim-2026-07-26`.
