### PR TITLE
fix(ci): green main — audit gate with expiring allowlist, honest container scan

### DIFF
--- a/.github/audit-allowlist.json
+++ b/.github/audit-allowlist.json
@@ -1,0 +1,25 @@
+{
+  "_comment": [
+    "Advisories the npm-audit CI gate is allowed to ignore, each with a reason and",
+    "an expiry. Consumed by scripts/ci-audit-gate.sh.",
+    "",
+    "An entry is NOT a dismissal -- the gate FAILS once review_by passes, so an",
+    "exception cannot rot silently. If it is still unfixable on that date, extend it",
+    "deliberately with fresh reasoning rather than by habit.",
+    "",
+    "Only add an entry when the vulnerable code path is genuinely unreachable in",
+    "this application, and say how that was established."
+  ],
+  "allow": [
+    {
+      "id": "GHSA-qwww-vcr4-c8h2",
+      "package": "react-router / react-router-dom",
+      "severity": "high",
+      "directory": "dashboard",
+      "reason": "React Router RSC Mode CSRF Bypass. The advisory is specific to RSC (React Server Components) mode. This dashboard is a client-only SPA: src/router.tsx uses createBrowserRouter + RouterProvider, no RSC or server-render API is imported anywhere in src/ (verified by grep for unstable_RSC, renderToPipeableStream, createStaticHandler, createStaticRouter, @react-router/node|server), and the build output is static files served by express.static from api/createApp.js. The vulnerable path is not reachable.",
+      "why_not_fixed": "Fixed only in react-router@8.3.0. react-router-dom has no 8.x (v8 merged the packages), and 8.3.0 requires react>=19.2.7 and node>=22.22.0 while the dashboard is on React 18.3.1 and CI/prod are Node 20. Closing it is a React 19 + Node 22 + router v7->v8 migration, tracked as Vikunja ops #2261 -- not a bump. Do NOT run `npm audit fix --force`: it downgrades react-router-dom 7.18.1 -> 7.11.0, which escapes this advisory only by re-entering four other react-router CVEs fixed in PR #194.",
+      "added": "2026-07-26",
+      "review_by": "2026-10-31"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,22 +321,14 @@ jobs:
     - name: Run dependency audit (Dashboard)
       run: ./scripts/ci-audit-gate.sh dashboard high
         
-    - name: Check for critical vulnerabilities (API)
-      run: |
-        cd api
-        VULNERABILITIES=$(npm audit --json 2>/dev/null | jq '.metadata.vulnerabilities.high + .metadata.vulnerabilities.critical' 2>/dev/null || echo "0")
-        if [ "$VULNERABILITIES" -gt "0" ]; then
-          echo "Found $VULNERABILITIES high/critical vulnerabilities in API"
-          npm audit --json | jq '.advisories' || true
-          exit 1
-        fi
-        
-    - name: Check for critical vulnerabilities (Dashboard)
-      run: |
-        cd dashboard
-        VULNERABILITIES=$(npm audit --json 2>/dev/null | jq '.metadata.vulnerabilities.high + .metadata.vulnerabilities.critical' 2>/dev/null || echo "0")
-        if [ "$VULNERABILITIES" -gt "0" ]; then
-          echo "Found $VULNERABILITIES high/critical vulnerabilities in Dashboard"
-          npm audit --json | jq '.advisories' || true
-          exit 1
-        fi
+    # The two "Check for critical vulnerabilities" steps that used to sit here
+    # were removed. They gated on `.metadata.vulnerabilities.high + .critical`
+    # for api/ and dashboard/ -- the same question the two "Run dependency
+    # audit" steps above already answer, but via a second, allowlist-unaware
+    # code path. Two gates on one question, disagreeing about exceptions, is
+    # how this job stayed red on an advisory that had already been assessed and
+    # documented. scripts/ci-audit-gate.sh is now the single gate.
+    #
+    # They were also partly dead: `npm audit --json | jq '.advisories'` reads an
+    # npm v6 field that is always null on npm v7+, so the intended debug output
+    # never printed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,10 @@ jobs:
         npx tsc --noEmit
         
     - name: Validate package.json (API)
-      run: |
-        cd api
-        npm audit --audit-level=high
-        
+      run: ./scripts/ci-audit-gate.sh api high
+
     - name: Validate package.json (Dashboard)
-      run: |
-        cd dashboard
-        npm audit --audit-level=high
+      run: ./scripts/ci-audit-gate.sh dashboard high
 
   unit-tests:
     name: Unit Tests
@@ -320,14 +316,10 @@ jobs:
         npm ci
         
     - name: Run dependency audit (API)
-      run: |
-        cd api
-        npm audit --audit-level=high
-        
+      run: ./scripts/ci-audit-gate.sh api high
+
     - name: Run dependency audit (Dashboard)
-      run: |
-        cd dashboard
-        npm audit --audit-level=high
+      run: ./scripts/ci-audit-gate.sh dashboard high
         
     - name: Check for critical vulnerabilities (API)
       run: |

--- a/.github/workflows/gitops-audit.yml
+++ b/.github/workflows/gitops-audit.yml
@@ -120,13 +120,10 @@ jobs:
 
       - name: Install dependencies and audit
         run: |
-          cd dashboard
-          npm ci
-          npm audit --audit-level=moderate
-          
-          cd ../api
-          npm ci
-          npm audit --audit-level=moderate
+          (cd dashboard && npm ci)
+          (cd api && npm ci)
+          ./scripts/ci-audit-gate.sh dashboard moderate
+          ./scripts/ci-audit-gate.sh api moderate
 
       - name: Check for sensitive files
         run: |

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -94,25 +94,35 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
+    # This repo ships NOTHING as a container: deploy.yml does `npm run build`
+    # then scp/ssh to CT 123 (gitopsdashboard.mgmt.lakehouse.wtf), and there is
+    # no Dockerfile anywhere in the tree -- only docker-compose templates that
+    # reference prebuilt third-party images.
+    #
+    # The previous version fabricated a node:20-alpine image here so it always
+    # had something to scan. That scanned an artifact which is never built or
+    # deployed, and it is why this job has been red since 2026-07-21: the single
+    # CRITICAL was CVE-2026-59873 in `tar 6.2.1` at
+    # usr/local/lib/node_modules/npm/node_modules/tar -- npm's OWN bundled tar
+    # inside the base image, not a dependency of this repo. No dependency work
+    # here could ever clear it, which is why it survived PR #194. It also
+    # uploaded SARIF, polluting code-scanning with alerts about an image that
+    # does not exist.
+    #
+    # So: scan a real image if one ever exists, and skip honestly if not.
     - name: Build Docker image
+      id: image
       run: |
         if [ -f "Dockerfile" ]; then
           docker build -t homelab-gitops-auditor:scan .
+          echo "built=true" >> "$GITHUB_OUTPUT"
         else
-          echo "Dockerfile not found, creating basic image for scanning"
-          cat > Dockerfile.scan << EOF
-        FROM node:20-alpine
-        WORKDIR /app
-        COPY package*.json ./
-        RUN npm ci --only=production
-        COPY . .
-        EXPOSE 3000
-        CMD ["npm", "start"]
-        EOF
-          docker build -f Dockerfile.scan -t homelab-gitops-auditor:scan .
+          echo "built=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No Dockerfile in this repo -- nothing here is containerized (deploy is npm build + rsync to CT 123). Skipping container scan rather than fabricating an image that is never deployed."
         fi
         
     - name: Run Trivy vulnerability scanner
+      if: steps.image.outputs.built == 'true'
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         image-ref: 'homelab-gitops-auditor:scan'
@@ -120,11 +130,13 @@ jobs:
         output: 'trivy-results.sarif'
         
     - name: Upload Trivy scan results
+      if: steps.image.outputs.built == 'true'
       uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
       with:
         sarif_file: 'trivy-results.sarif'
         
     - name: Check for critical vulnerabilities
+      if: steps.image.outputs.built == 'true'
       run: |
         CRITICAL=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
           aquasec/trivy image --format json homelab-gitops-auditor:scan | \

--- a/scripts/ci-audit-gate.sh
+++ b/scripts/ci-audit-gate.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# npm-audit CI gate with a documented, EXPIRING allowlist.
+#
+# Why this exists: `npm audit --audit-level=high` has only one lever -- the
+# threshold. When a single unfixable advisory appears, the choices are to leave
+# the gate red forever (so nobody reads it, and the next real vulnerability
+# lands unnoticed) or to lower the threshold (so the gate stops catching the
+# class entirely). Both are worse than an explicit, justified exception with an
+# expiry date.
+#
+# This gate fails on ANY advisory at or above <level> that is not listed in
+# .github/audit-allowlist.json, and additionally fails when an allowlist entry
+# passes its review_by date -- so an exception cannot rot silently.
+#
+# Usage: scripts/ci-audit-gate.sh <directory> <level>
+#   level: low | moderate | high | critical
+set -uo pipefail
+
+DIR="${1:?usage: ci-audit-gate.sh <directory> <level>}"
+LEVEL="${2:?usage: ci-audit-gate.sh <directory> <level>}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ALLOWLIST="$REPO_ROOT/.github/audit-allowlist.json"
+
+cd "$REPO_ROOT/$DIR" || { echo "::error::no such directory: $DIR"; exit 2; }
+
+# npm audit exits non-zero when it finds anything at/above the level; we do our
+# own gating, so capture the JSON and ignore its exit status here.
+AUDIT_FILE="$(mktemp)"
+trap 'rm -f "$AUDIT_FILE"' EXIT
+npm audit --json >"$AUDIT_FILE" 2>/dev/null
+if [ ! -s "$AUDIT_FILE" ]; then
+  echo "::error::npm audit produced no output in $DIR (is the dependency tree installed?)"
+  exit 2
+fi
+
+# The audit JSON goes via a FILE, not stdin: stdin is already carrying the
+# python script below, and a command has only one stdin.
+ALLOWLIST="$ALLOWLIST" DIR="$DIR" LEVEL="$LEVEL" AUDIT_FILE="$AUDIT_FILE" python3 - <<'PY'
+import json, os, sys, datetime
+
+ORDER = {"info": 0, "low": 1, "moderate": 2, "high": 3, "critical": 4}
+level = ORDER[os.environ["LEVEL"]]
+directory = os.environ["DIR"]
+
+with open(os.environ["AUDIT_FILE"]) as fh:
+    audit = json.load(fh)
+
+allow = {}
+try:
+    with open(os.environ["ALLOWLIST"]) as fh:
+        for entry in json.load(fh).get("allow", []):
+            allow[entry["id"]] = entry
+except FileNotFoundError:
+    pass
+
+# Collect advisories at/above the threshold, keyed by GHSA id.
+found = {}
+for name, vuln in (audit.get("vulnerabilities") or {}).items():
+    for via in vuln.get("via") or []:
+        if not isinstance(via, dict):
+            continue
+        sev = via.get("severity", "info")
+        if ORDER.get(sev, 0) < level:
+            continue
+        ghsa = (via.get("url") or "").rsplit("/", 1)[-1]
+        found.setdefault(ghsa, {"severity": sev, "packages": set(), "title": via.get("title", "")})
+        found[ghsa]["packages"].add(name)
+
+today = datetime.date.today()
+blocking, expired = [], []
+
+for ghsa, info in sorted(found.items()):
+    entry = allow.get(ghsa)
+    if entry is None:
+        blocking.append((ghsa, info))
+        continue
+    # An allowlisted advisory still blocks once its review date passes.
+    review_by = datetime.date.fromisoformat(entry["review_by"])
+    if today > review_by:
+        expired.append((ghsa, info, entry, review_by))
+    else:
+        pkgs = ", ".join(sorted(info["packages"]))
+        print(f"::notice::[{directory}] allowing {ghsa} ({info['severity']}, {pkgs}) "
+              f"until {review_by} -- {entry['reason'][:160]}")
+
+# An allowlist entry whose advisory is gone is dead weight; report, don't fail.
+for ghsa, entry in allow.items():
+    if entry.get("directory") == directory and ghsa not in found:
+        print(f"::warning::[{directory}] allowlist entry {ghsa} no longer matches any "
+              f"advisory -- remove it from .github/audit-allowlist.json")
+
+rc = 0
+for ghsa, info, entry, review_by in expired:
+    print(f"::error::[{directory}] allowlist entry {ghsa} EXPIRED on {review_by}. "
+          f"Re-assess it and either fix the advisory or extend review_by deliberately. "
+          f"Context: {entry.get('why_not_fixed', '')[:200]}")
+    rc = 1
+
+for ghsa, info in blocking:
+    pkgs = ", ".join(sorted(info["packages"]))
+    print(f"::error::[{directory}] {info['severity']} advisory {ghsa} in {pkgs} "
+          f"is not allowlisted: {info['title']}")
+    rc = 1
+
+if rc == 0 and not found:
+    print(f"[{directory}] npm audit clean at level '{os.environ['LEVEL']}'")
+elif rc == 0:
+    print(f"[{directory}] no blocking advisories at level '{os.environ['LEVEL']}' "
+          f"({len(found)} allowlisted)")
+
+sys.exit(rc)
+PY


### PR DESCRIPTION
main has been red since **2026-07-21** across three workflows. Four failing steps, three causes, none fixable by dependency work — which is why PR #194 did not clear them.

## Cause 1 — dashboard react-router advisory (3 of the 4 failing steps)

`GHSA-qwww-vcr4-c8h2` is fixed only in `react-router@8.3.0`, which requires `react>=19.2.7` and `node>=22.22.0`; the dashboard is React 18.3.1 on Node 20. That migration is **ops #2261** — a project, not a bump.

`npm audit --audit-level=high` has exactly one lever, the threshold. So the choices were: leave main red forever (nobody reads a permanently-red gate, and the next *real* advisory lands unnoticed), or lower the threshold (the gate stops catching the class). Both are worse than an explicit, justified, **expiring** exception:

- `.github/audit-allowlist.json` — the advisory, why it is unreachable here, why it is not fixable, and a `review_by`
- `scripts/ci-audit-gate.sh` — fails on any advisory at/above level that is **not** allowlisted, **and** fails once an entry passes `review_by`

That second property is the point: **the exception cannot rot silently.** It also warns when an entry no longer matches any advisory, so dead entries get removed.

The unreachability claim was **verified, not assumed**: `src/router.tsx` uses `createBrowserRouter` + `RouterProvider`; no RSC or server-render API appears anywhere in `src/` (grepped `unstable_RSC`, `renderToPipeableStream`, `createStaticHandler`, `createStaticRouter`, `@react-router/node|server`); the build is static files served by `express.static` in `api/createApp.js`. The advisory is RSC-mode-specific, so the vulnerable path is not reachable.

Wired into the **3 gating call sites** only. The `continue-on-error: true` audits in `security-scan.yml` / `security-enhanced.yml` are advisory, not gates, and are untouched.

## Cause 2 — a container scan of an image that does not exist

The job fabricated a `node:20-alpine` image (because the repo has **no Dockerfile**) and gated on its CRITICAL count. Nothing here is containerized: `deploy.yml` runs `npm run build` and scp/ssh to CT 123, and the only compose files reference prebuilt third-party images.

The single CRITICAL was **`CVE-2026-59873`, `tar 6.2.1`, at `usr/local/lib/node_modules/npm/node_modules/tar`** — npm's **own bundled tar inside the base image**. Not a dependency of this repo, so no dependency work could ever clear it. Reproduced locally to establish this rather than inferring from the count.

That also resolves the instrument disagreement in **ops #2262** (gate said 1 CRITICAL, code-scanning said max HIGH): the gate runs `aquasec/trivy:latest` while the SARIF step runs pinned `trivy-action@v0.36.0` — different scanners, different DBs, both looking at a fabricated image.

Now it scans a real image if a Dockerfile ever exists and skips honestly if not, which also stops it uploading SARIF about a non-existent image.

## Verification — the gate was made to fail on purpose

| scenario | result |
|---|---|
| allowlisted + in date | `rc=0`, notice explains the exception |
| allowlist entry **expired** | `rc=1` |
| allowlist **emptied** | `rc=1` on the real advisory |
| entry for an advisory that is gone | `rc=0` + warning to remove it |
| `api` (clean tree) | `rc=0` |

shellcheck clean; all three workflow files parse; the gate reads the lockfile so it does not depend on `npm ci` having run first.

Refs: ops #2261, #2262, #2257