### PR TITLE
fix(deps): clear 5 high in the ROOT tree deployed to CT 123 (ops #2268)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
         cd dashboard
         npx tsc --noEmit
         
+    - name: Validate package.json (root)
+      run: ./scripts/ci-audit-gate.sh . high
+
     - name: Validate package.json (API)
       run: ./scripts/ci-audit-gate.sh api high
 
@@ -315,6 +318,9 @@ jobs:
         cd dashboard
         npm ci
         
+    - name: Run dependency audit (root)
+      run: ./scripts/ci-audit-gate.sh . high
+
     - name: Run dependency audit (API)
       run: ./scripts/ci-audit-gate.sh api high
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@modelcontextprotocol/server-github": "^2025.4.8",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
-        "axios": "^1.16.0",
+        "axios": "^1.18.0",
         "chokidar": "^3.5.3",
         "concurrently": "^9.1.0",
         "dotenv": "^16.3.1",
@@ -1900,9 +1900,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -2127,20 +2127,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -2150,16 +2150,29 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3263,9 +3276,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -5361,9 +5374,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.0.tgz",
-      "integrity": "sha512-Bul4Ha6J8IqzFrb0B1xpVzkC3S0sk43dmLSnhFOn8eJlZiLwL5WO6cRymmjaADdCMjUcCpj2ce8hZI6O4ZFSug==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
@@ -6664,9 +6677,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7164,9 +7177,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -7423,17 +7436,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@modelcontextprotocol/server-github": "^2025.4.8",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
-    "axios": "^1.16.0",
+    "axios": "^1.18.0",
     "chokidar": "^3.5.3",
     "concurrently": "^9.1.0",
     "dotenv": "^16.3.1",
@@ -80,7 +80,7 @@
     "uuid": "^14.0.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@isaacs/brace-expansion": "^5.0.1",
-    "tar": "^7.5.7",
+    "tar": "^7.5.21",
     "diff": "^5.2.2",
     "qs": "^6.14.2",
     "minimatch": "^10.2.1",
@@ -88,7 +88,12 @@
     "path-to-regexp": "^8.4.0",
     "hono": "^4.12.18",
     "@hono/node-server": "^1.19.13",
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "brace-expansion": "^5.0.8",
+    "fast-uri": "^3.1.4",
+    "shell-quote": "^1.8.5",
+    "mongoose": "^8.24.1",
+    "body-parser": "^2.3.0"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
The root `package.json` was never in scope for PR #194 (which fixed `api/` and `dashboard/`), and **it is deployed**: `deploy.yml` copies `package.json` + `package-lock.json` into `deploy-staging`, and the on-box step runs `npm ci --omit=dev` in the staging root. These are production dependencies on CT 123.

### How this surfaced

Triaging the 25 Trivy code-scanning alerts. **18 sit under `app/node_modules/*`**, which looked like leftovers from the fabricated scan image removed in PR #196 — but `app/` was that image's copy of the **root tree**. I had suggested bulk-dismissing all 25; doing so would have hidden real exposure. Only the **7** under `usr/local/lib/node_modules/npm/*` were image-only, and those are dismissed.

### Changes

| | from | to | |
|---|---|---|---|
| `axios` (direct) | `^1.16.0` | `^1.18.0` | 10 advisories incl. 1 high — same version PR #194 gave `dashboard/` |
| `tar` (override) | `^7.5.7` | `^7.5.21` | `^7.5.7` resolved to 7.5.19; `<=7.5.20` vulnerable |
| `brace-expansion` | — | `^5.0.8` | GHSA-mh99-v99m-4gvg (high) |
| `fast-uri` | — | `^3.1.4` | 2 high |
| `shell-quote` | — | `^1.8.5` | 1 high |
| `mongoose` | — | `^8.24.1` | |
| `body-parser` | — | `^2.3.0` | |

**5 high + 4 moderate + 1 low → 0 high, 4 moderate, 0 low.**

### Also: gates the root tree in CI

This was the blind spot that produced the problem. `ci-audit-gate.sh` ran for `api/` and `dashboard/` but never the root, so the only thing ever inspecting these was a container scan of a fabricated image — and that scan is now correctly gone, which would have left the root tree with **no vulnerability scanning at all**.

### Deliberately not fixed

`@hono/node-server` GHSA-frvp-7c67-39w9 (moderate). Fixed in `>=2.0.5`, but `@modelcontextprotocol/sdk` declares `^1.19.9`, so an override to v2 forces a major past what the SDK supports. The advisory is a path traversal in `serve-static` **on Windows** via an encoded backslash; CT 123 is Linux, so it is not reachable. Left visible at moderate rather than allowlisted, since the gate runs at `high`.

### Verified

- **Resolved versions in the lockfile, not just the ranges**: axios 1.18.1, tar 7.5.22, brace-expansion 5.0.8, fast-uri 3.1.4, shell-quote 1.10.0, mongoose 8.24.1, body-parser 2.3.0
- `npm ci --omit=dev` — the deploy's exact command — succeeds, 360 packages
- `brace-expansion ^5` is paired with `minimatch ^10` (already pinned), so the ESLint break PR #194 hit is not reproduced
- `sqlite3` stays **6.0.1, untouched**. It fails to load on the dev box with `GLIBC_2.38 not found` — a prebuilt-vs-host mismatch on CT 128, not this change: it builds and loads fine from source, and CT 123 compiles it from source during deploy anyway
- `ci-audit-gate.sh` passes for `.`, `api`, `dashboard` at `high`

Refs: ops #2268, #2262, #2257