### PR TITLE
fix(deps): make root sqlite3 load on old-glibc hosts (ops #2269)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "discovery:stop": "node scripts/wiki-discovery-cron.js stop",
     "discovery:status": "node scripts/wiki-discovery-cron.js status",
     "discovery:run-full": "node scripts/wiki-discovery-cron.js run-once daily-full-discovery",
-    "discovery:test": "jest tests/discovery/discovery-system.test.js"
+    "discovery:test": "jest tests/discovery/discovery-system.test.js",
+    "postinstall": "node scripts/ensure-sqlite3.js"
   },
   "keywords": [
     "gitops",

--- a/scripts/ensure-sqlite3.js
+++ b/scripts/ensure-sqlite3.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * postinstall guard for the sqlite3 native binary.
+ *
+ * sqlite3 v6 ships prebuilt N-API binaries linked against a newer glibc
+ * (GLIBC_2.38) than Debian 12 provides (2.36). On such hosts — the dev-env
+ * container (CT 128) and the production CT (gitopsdashboard) — the prebuilt
+ * fails to load at require() time.
+ *
+ * THIS IS THE ROOT-TREE COPY. It is a deliberate mirror of
+ * api/scripts/ensure-sqlite3.js; keep the two in sync. Both are needed because
+ * root/ and api/ are installed as SEPARATE npm trees (deploy.yml runs
+ * `npm ci --omit=dev` in each), and require.resolve() here targets whichever
+ * tree the script sits in.
+ *
+ * Without this, /opt/gitops/node_modules/sqlite3 never loaded on CT 123, and
+ * the four consumers outside api/ were latently dead — including
+ * scripts/backup-wiki-agent.js. The service itself was unaffected because it
+ * runs from /opt/gitops/api, whose own copy IS built from source, which is
+ * exactly why nothing surfaced it. CI is green regardless: ubuntu-latest has
+ * glibc >= 2.38, so the prebuilt loads there and the failure is invisible to
+ * it by construction. See ops #2269.
+ *
+ * CI runs on ubuntu-latest (glibc >= 2.38), where the prebuilt loads fine, so
+ * this script is a no-op there and adds no build time.
+ *
+ * Strategy: try to load sqlite3. If it loads, do nothing. If it fails to load,
+ * compile it from source with node-gyp against the host toolchain, which links
+ * the local glibc. Idempotent and safe to run on every install.
+ *
+ * This makes a fresh `npm ci` self-healing on old-glibc hosts and supersedes
+ * the manual `npm rebuild sqlite3 --build-from-source` step in deploy.yml (kept
+ * there as belt-and-suspenders).
+ *
+ * See homelab-gitops task #2002 and the global env learning
+ * "Native Node modules: try npm rebuild --build-from-source".
+ */
+
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+function firstLine(msg) {
+  return String(msg).split('\n')[0];
+}
+
+// 1. Does the installed sqlite3 binary load in this process?
+try {
+  require('sqlite3');
+  // Prebuilt loads (CI / modern glibc / already compiled). Nothing to do.
+  process.exit(0);
+} catch (loadErr) {
+  console.warn(
+    '[ensure-sqlite3] prebuilt sqlite3 failed to load (' +
+      firstLine(loadErr.message) +
+      '); rebuilding from source...'
+  );
+}
+
+// 2. Locate the sqlite3 module dir and a node-gyp to build it with.
+//    Prefer npm's bundled node-gyp (always present during a lifecycle script,
+//    even under --omit=dev); fall back to a resolved copy for manual runs.
+let sqliteDir;
+try {
+  sqliteDir = path.dirname(require.resolve('sqlite3/package.json'));
+} catch (err) {
+  console.error('[ensure-sqlite3] cannot locate sqlite3 to rebuild: ' + err.message);
+  process.exit(1);
+}
+
+let nodeGyp = process.env.npm_config_node_gyp;
+if (!nodeGyp) {
+  try {
+    nodeGyp = require.resolve('node-gyp/bin/node-gyp.js', { paths: [sqliteDir] });
+  } catch (err) {
+    console.error(
+      '[ensure-sqlite3] cannot locate node-gyp to rebuild sqlite3: ' + err.message
+    );
+    process.exit(1);
+  }
+}
+
+// 3. Compile from source.
+try {
+  execFileSync(process.execPath, [nodeGyp, 'rebuild'], {
+    cwd: sqliteDir,
+    stdio: 'inherit',
+  });
+} catch (err) {
+  console.error('[ensure-sqlite3] node-gyp rebuild failed: ' + firstLine(err.message));
+  process.exit(1);
+}
+
+// 4. Verify the freshly built binary loads. require() cached the earlier
+//    failure in THIS process, so re-check in a clean child process.
+try {
+  execFileSync(process.execPath, ['-e', "require('sqlite3')"], {
+    cwd: __dirname,
+    stdio: 'ignore',
+  });
+} catch (err) {
+  console.error(
+    '[ensure-sqlite3] sqlite3 still fails to load after rebuild: ' + firstLine(err.message)
+  );
+  process.exit(1);
+}
+
+console.warn('[ensure-sqlite3] sqlite3 rebuilt from source and loads OK.');


### PR DESCRIPTION
`/opt/gitops/node_modules/sqlite3` has **never loaded** on CT 123. sqlite3 v6 ships prebuilt N-API binaries linked against `GLIBC_2.38`; CT 123 (and the dev box CT 128) are Debian 12 with **2.36**:

```
Error: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
  (required by /opt/gitops/node_modules/sqlite3/build/Release/node_sqlite3.node)
```

**The repo already solved this** — `api/scripts/ensure-sqlite3.js` is a postinstall guard that tries to load sqlite3 and, if the prebuilt fails, rebuilds from source against the host toolchain. It was simply never applied to the **root** tree. `root/` and `api/` are installed as separate npm trees (`deploy.yml` runs `npm ci --omit=dev` in each) and `require.resolve` targets whichever tree the script sits in, so each needs its own copy.

### Why nobody noticed

- **The service is unaffected.** `gitops-audit-api` runs with `WorkingDirectory=/opt/gitops/api`, and `api/node_modules/sqlite3` *is* built from source by the existing guard. `/health` stays 200.
- **CI is green regardless.** `ubuntu-latest` has glibc ≥ 2.38, so the prebuilt loads there and this cannot reproduce in CI.

So it only manifests on the hosts nobody was checking.

### What was actually broken

Four consumers outside `api/` resolve to the root copy (verified with `require.resolve`; there is no `scripts/node_modules` shadowing it):

| file | |
|---|---|
| `scripts/backup-wiki-agent.js` | documented in `scripts/README.md`, `docs/database-schema.md` |
| `scripts/migrate-wiki-agent.js` | documented likewise |
| `scripts/test-migrations.js` | |
| `scripts/services/database/deployment-repository.js` | see below |

None is on a cron or timer, so nothing failed on a schedule — they failed when run by hand, which for `backup-wiki-agent.js` means failing exactly when someone reaches for it during an incident.

### Verified on CT 128 (glibc 2.36 — same failing condition as CT 123)

Running the deploy's own command, `npm ci --omit=dev`:

```
[ensure-sqlite3] prebuilt sqlite3 failed to load (GLIBC_2.38 not found); rebuilding from source...
[ensure-sqlite3] sqlite3 rebuilt from source and loads OK.
added 360 packages in 1m
```

Then `require.resolve`/`require` of sqlite3 from `scripts/` succeeds, and the first three consumers require cleanly.

### One of the four is still broken — for an unrelated reason

`scripts/services/database/deployment-repository.js` line 2 is `require('sqlite')`, and **`sqlite` is not a dependency of any manifest in this repo** — so that file has never been loadable on any host, glibc notwithstanding. Pulling that thread further shows `api/repositories/deployment-repository.js` (which its integration test imports) **does not exist**, and `api/services/webhook-processor.js` cannot load either. That is a separate dead-code cluster; filed on its own rather than absorbed here.

### Behaviour change worth flagging

If the prebuilt fails **and** node-gyp cannot build, root `npm ci` now **fails** instead of silently succeeding with an unusable sqlite3. That is intended — failing loudly beats shipping a module that throws on require. CT 123 demonstrably has the toolchain, since `api/` already compiles there every deploy. On CI the guard is a no-op and adds no build time.

Refs: ops #2269