### PR TITLE
fix(webhook): repair config-manager import; stop CI faking integration tests (ops #2270)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,20 +189,30 @@ jobs:
           sleep 10
         fi
         
+    # This step used to be `|| echo ...` AND `continue-on-error: true` -- doubly
+    # suppressed, so the job reported success no matter what happened. The
+    # underlying non-zero exit was NOT a test failure: the 8 integration tests
+    # pass. It came from jest's coverage THRESHOLDS, which are global and cannot
+    # be met by running one project in isolation. Suppressing the whole step to
+    # silence a coverage gate meant a genuine integration-test regression would
+    # also have gone unreported. Running with --coverage=false gates on the
+    # thing this job is named for; coverage is enforced by the full test run.
     - name: Run integration tests (API)
       run: |
         cd api
-        npm run test:integration || echo "Integration tests not configured for API"
-      continue-on-error: true
+        npm run test:integration -- --coverage=false
       env:
         NODE_ENV: test
         DATABASE_URL: postgresql://test_user:test_password@localhost:5432/homelab_gitops_test
-        
-    - name: Run integration tests (Dashboard)
-      run: |
-        cd dashboard
-        npm run test:integration || echo "Integration tests not configured for Dashboard"
-      continue-on-error: true
+
+    # The "Run integration tests (Dashboard)" step was removed: dashboard has no
+    # `test:integration` script, so it errored on every run and was swallowed by
+    # the same `|| echo` + continue-on-error. A step that can only ever fail
+    # silently is worse than no step. Its unit tests run in the Unit Tests job.
+    #
+    # NOT wired up here: the ROOT tests/integration suite (`npm run
+    # test:integration` at the repo root). It is currently non-functional -- see
+    # the header of tests/integration/jest.config.js. Tracked in ops #2271.
         
     - name: Test audit script validation
       run: |

--- a/api/services/webhook-processor.js
+++ b/api/services/webhook-processor.js
@@ -1,5 +1,9 @@
 const path = require('path');
-const { ConfigManager } = require('../config/utils/config-manager');
+// NOTE: config/utils/config-manager.js does `module.exports = ConfigManager`
+// (a direct export), and lives at the REPO ROOT -- so from api/services/ the
+// path is ../../config, not ../config. The previous line had both wrong, which
+// is one of three reasons this module cannot load. See ops #2270.
+const ConfigManager = require('../../config/utils/config-manager');
 
 /**
  * WebhookProcessor Class

--- a/api/services/webhook/enhancedWebhookHandler.js
+++ b/api/services/webhook/enhancedWebhookHandler.js
@@ -889,7 +889,24 @@ class EnhancedWebhookHandler extends EventEmitter {
     console.log(`🚀 Repository dispatch: ${repository.full_name} - Action: ${action}`);
     
     try {
-      // Initialize WebhookProcessor if not already done
+      // Initialize WebhookProcessor if not already done.
+      //
+      // HEADS UP: this require currently THROWS, so repository_dispatch events
+      // never produce a deployment -- they fall to the catch below, log, and
+      // emit 'deployment_failed'. The chain
+      //   webhook-processor -> scripts/services/home-assistant-deployer
+      //                     -> scripts/services/database/deployment-repository
+      // is a COMPLETE Home-Assistant deployment subsystem whose dependencies
+      // were never declared: cors, helmet, express-rate-limit, socket.io and
+      // sqlite are absent from every manifest in this repo, so it has never
+      // run since it was written.
+      //
+      // Left inert deliberately (ops #2270). home-assistant-config already
+      // deploys itself via its own GitHub Actions pipeline, nothing in the
+      // homelab sends repository_dispatch here, and switching this on would
+      // make an untested HA deployment path live. Do not "fix" it by adding
+      // the missing dependencies without deciding whether this subsystem is
+      // wanted at all.
       if (!this.webhookProcessor) {
         const { WebhookProcessor } = require('../webhook-processor');
         this.webhookProcessor = new WebhookProcessor();

--- a/tests/integration/jest.config.js
+++ b/tests/integration/jest.config.js
@@ -1,3 +1,30 @@
+// ⚠ NON-FUNCTIONAL — this suite has never run. Do not trust a green pipeline
+// as evidence that it does. Tracked in ops #2271.
+//
+// Four independent reasons, all still present below:
+//
+//   1. rootDir defaults to this config's OWN directory, so every
+//      '<rootDir>/tests/integration/...' path resolves to
+//      tests/integration/tests/integration/... and matches nothing.
+//      `jest --listTests` returns zero files. The sibling that works,
+//      tests/jest.unit.config.js, sets `rootDir: '..'` -- copy that.
+//   2. `moduleNameMapping` (below) is a typo for `moduleNameMapper`; jest
+//      reports it as an unknown option and ignores it.
+//   3. setupFilesAfterEnv / globalSetup / globalTeardown point at paths that
+//      do not resolve for reason 1, so jest aborts with a Validation Error
+//      before running anything. The target files DO exist -- only the paths
+//      are wrong.
+//   4. babel-jest, jest-html-reporters, jest-junit and supertest are all
+//      referenced here but are absent from every manifest in this repo.
+//
+// And once it does run, tests/integration/database/deployment-repository.test.js
+// imports ../../../api/repositories/deployment-repository, which does not
+// exist. So reviving this needs a decision about that test, not just config
+// repair.
+//
+// CI does not invoke this suite at all -- the "Integration Tests" job runs the
+// api/ and dashboard/ suites only.
+
 module.exports = {
   displayName: 'Integration Tests',
   testMatch: [


### PR DESCRIPTION
ops #2270 was filed as a "dead-code cluster". **It is not dead code** — it is a *complete* Home Assistant deployment subsystem that has never once run.

`scripts/services/` contains deployer, queue, webhook-handler, mcp-coordinator, repository and utils, and **every module it requires exists**. What is missing is the dependency *declarations*: `cors`, `helmet`, `express-rate-limit`, `socket.io` and `sqlite` appear in no manifest in this repo. So this chain dies partway:

```
api/routes/webhooks.js        (top-level, live)
 -> enhancedWebhookHandler    (top-level, live)
 -> webhook-processor         (lazy, line 894)
 -> scripts/services/home-assistant-deployer
 -> scripts/services/database/deployment-repository
```

`repository_dispatch` webhooks therefore never produce a deployment — they fall into the existing try/catch, log, and emit `deployment_failed`. **Degraded, not crashing**, which is why nothing surfaced it.

### Left inert deliberately

`home-assistant-config` already deploys itself via its own Actions pipeline, nothing in the homelab sends `repository_dispatch` here, and declaring the missing deps would make an **untested HA deployment path live**. That is a decision, not a cleanup — so this documents it at the require site rather than doing it.

### What is fixed

**1. `api/services/webhook-processor.js` had two bugs in one line.**

```js
const { ConfigManager } = require('../config/utils/config-manager');
```

`config-manager.js` lives at the **repo root** (so `../../config` from `api/services/`, not `../config`) and does `module.exports = ConfigManager` — a direct export, so destructuring yields `undefined`. Both wrong. The module now loads.

This advances the failure point from module-load to `initialize()`, with **only a read-only config load in between** — no deployment side effects. The subsystem stays inert, failing at the deployer require as before.

**2. CI's "Integration Tests" job was reporting success while running nothing real.**

Both steps had `|| echo ...` **and** `continue-on-error: true`. The underlying non-zero exit was *not* a test failure — the 8 api integration tests pass — it came from jest's global **coverage thresholds**, which a single-project run cannot meet. Suppressing the whole step to silence a coverage gate meant a genuine integration regression would also have gone unreported.

Now runs `npm run test:integration -- --coverage=false` unsuppressed (verified: **8 passed, exit 0**). Coverage stays enforced by the full test run.

The dashboard step is **removed**: dashboard has no `test:integration` script, so it errored every run and was swallowed. A step that can only fail silently is worse than no step.

**3. `tests/integration/jest.config.js`** now carries a header stating it has never run and why — unset `rootDir`, `moduleNameMapping` typo, unresolvable setup paths, 6 missing devDeps — so the next reader does not mistake a green pipeline for evidence it works.

### Follow-up

**ops #2271** tracks reviving the root test suite, plus the systemic `config-manager` import inconsistency in four other callers (three of which have the wrong path and/or a destructured import against a direct export).

Refs: ops #2270, #2271