### PR TITLE
fix(tests): move security suite expect.extend to setupFilesAfterEnv

### DIFF
--- a/tests/security/jest.config.js
+++ b/tests/security/jest.config.js
@@ -17,11 +17,15 @@ module.exports = {
   ],
   
   // Setup files
-  setupFiles: [
-    '<rootDir>/tests/setup/jest.setup.js'
-  ],
-  
+  // NOTE: tests/setup/jest.setup.js calls expect.extend(...) at load time, so
+  // it must run in setupFilesAfterEnv (after the test framework/`expect` is
+  // installed), not setupFiles (which runs before the framework exists and
+  // is meant for environment polyfills only). The sibling tests/jest.unit.config.js
+  // wires this same file via setupFilesAfterEnv -- copy that ordering here.
+  // Putting it in setupFiles caused every test file to fail immediately with
+  // "ReferenceError: expect is not defined". See ops #2271.
   setupFilesAfterEnv: [
+    '<rootDir>/tests/setup/jest.setup.js',
     '<rootDir>/tests/security/setup/security-setup.js'
   ],
   


### PR DESCRIPTION
## Summary
- ops #2271 (scoped): fixes the setup-file ordering bug that stopped the security test suite from RUNNING (it collected 5 files but errored `ReferenceError: expect is not defined` on all 5).
- Cause: `tests/security/jest.config.js` wired the shared `tests/setup/jest.setup.js` (which calls `expect.extend(...)` at load time) via `setupFiles` instead of `setupFilesAfterEnv`. `setupFiles` runs before the test framework/`expect` global exists. `tests/jest.unit.config.js` wires the same file via `setupFilesAfterEnv` — mirrored that ordering.
- Audited the other four suites PR #200 got collecting (integration, e2e, disaster-recovery, performance) for the same shape. None had it — no further config changes made.

## What this does NOT do (deliberately out of scope)
- Does not author `tests/integration/setup/test-environment.js` or `api/repositories/deployment-repository.js` — both still missing, block integration/e2e/disaster-recovery from actually passing.
- Does not wire any of these suites into CI (CI runs only the api/ integration suite, per today's decision).
- Does not add puppeteer.

## Test plan (per suite, `npx jest --config tests/<suite>/jest.config.js`)

| Suite | Before this PR | After this PR |
|---|---|---|
| security | 5 suites collected, 5 failed — `ReferenceError: expect is not defined` (0 tests ran) | 5 suites collected, 5 failed — now blocked by missing `tests/integration/setup/test-environment.js` (the known out-of-scope module). No more ReferenceError. |
| integration | 6 suites collected, 6 failed — missing `./test-environment` (out of scope) | unchanged (no config bug here) |
| e2e | blocked before collection — `globalSetup` exports `{globalSetup, getTestEnvironment}` instead of a bare function (pre-existing, unrelated bug) | unchanged (no config bug here) |
| disaster-recovery | 6 suites collected, 6 failed — missing `../../integration/setup/test-environment` (out of scope); reporter also crashes on a missing `logo.png` before printing the summary line (pre-existing, unrelated) | unchanged (no config bug here) |
| performance | blocked before collection — `globalSetup` runs `npm run db:reset`, an npm script that doesn't exist (pre-existing, unrelated bug) | unchanged (no config bug here) |

These suites have never run before, so the remaining failures are expected — this PR's job was to make them execute, not to make them green. No assertions weakened, nothing skipped/deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)