### PR TITLE
fix(tests): clear the 4 blockers stopping the root suites from executing at all

### DIFF
--- a/tests/disaster-recovery/jest.config.js
+++ b/tests/disaster-recovery/jest.config.js
@@ -37,7 +37,11 @@ module.exports = {
       publicPath: './coverage/disaster-recovery',
       filename: 'disaster-recovery-report.html',
       pageTitle: 'Disaster Recovery Test Report',
-      logoImgPath: './logo.png',
+      // './logo.png' doesn't exist on disk -- jest-html-reporters throws
+      // before printing a summary. undefined matches the convention already
+      // used in tests/security/jest.config.js and tests/e2e/jest.config.js
+      // (the reporter renders without a logo). See ops #2279.
+      logoImgPath: undefined,
       hideIcon: true,
       expand: true,
       openReport: false

--- a/tests/e2e/setup/global-setup.js
+++ b/tests/e2e/setup/global-setup.js
@@ -1,6 +1,13 @@
-const { setup: setupDevServer } = require('@jest/test-sequencer');
-const E2ETestEnvironment = require('./e2e-environment');
-const GitHubSimulator = require('../utils/github-simulator');
+// NOTE: this file used to `require('@jest/test-sequencer')` for a `setup`
+// export that was destructured into `setupDevServer` and never referenced
+// anywhere below -- dead code. The package isn't a declared dependency, so
+// requiring it is fragile (it only worked here because jest itself pulls it
+// in transitively). Removed rather than installed. See ops #2279.
+// Both modules export a named `{ ClassName }` object, not a bare class --
+// destructure to get the actual constructor. Third pre-existing defect
+// found while verifying the two listed e2e blockers; see ops #2279.
+const { E2ETestEnvironment } = require('./e2e-environment');
+const { GitHubSimulator } = require('../utils/github-simulator');
 const MonitoringUtils = require('../utils/monitoring-utils');
 const fs = require('fs').promises;
 const path = require('path');
@@ -184,7 +191,9 @@ function getTestEnvironment() {
   };
 }
 
-module.exports = {
-  globalSetup,
-  getTestEnvironment
-};
+// jest's `globalSetup` config option requires the module to export a bare
+// function directly (module.exports = fn), not an object containing one.
+// getTestEnvironment is attached as a property so it remains available to
+// anything that still wants to `require(...).getTestEnvironment`. See ops #2279.
+module.exports = globalSetup;
+module.exports.getTestEnvironment = getTestEnvironment;

--- a/tests/performance/setup/global-setup.js
+++ b/tests/performance/setup/global-setup.js
@@ -1,41 +1,19 @@
-const { execSync } = require('child_process');
 const path = require('path');
 
+// NOTE: this used to execSync('npm run db:reset') and 'npm run test:env:start'
+// followed by a curl health check against http://localhost:3000/health.
+// Neither script exists in the root or api/ package.json (confirmed by grep),
+// so this crashed before a single test ran. Writing those scripts would mean
+// deciding these suites own a real ephemeral DB + managed server lifecycle --
+// a bigger design/infra decision than a test-blocker fix warrants. Removed
+// the calls instead (lower risk): the suite now runs its load/stress tests
+// against whatever target the test files themselves already point at, and
+// failures show up as real per-test results rather than a crashed globalSetup.
+// See ops #2279.
 module.exports = async () => {
   console.log('🚀 Setting up performance test environment...');
-  
+
   try {
-    // Set up performance test database
-    console.log('📊 Setting up performance test database...');
-    execSync('npm run db:reset', { 
-      stdio: 'inherit',
-      env: { 
-        ...process.env, 
-        DB_NAME: 'homelab_gitops_auditor_performance_test' 
-      }
-    });
-    
-    // Start test server if not already running
-    console.log('🌐 Starting test server...');
-    execSync('npm run test:env:start', { 
-      stdio: 'inherit',
-      timeout: 30000 
-    });
-    
-    // Wait for server to be ready
-    console.log('⏳ Waiting for server to be ready...');
-    await new Promise(resolve => setTimeout(resolve, 5000));
-    
-    // Verify server is responding
-    const { execSync: execSyncImport } = require('child_process');
-    try {
-      execSyncImport('curl -f http://localhost:3000/health', { timeout: 10000 });
-      console.log('✅ Test server is ready');
-    } catch (error) {
-      console.error('❌ Test server health check failed:', error.message);
-      throw error;
-    }
-    
     // Set up performance monitoring infrastructure
     console.log('📈 Setting up performance monitoring...');
     

--- a/tests/security/jest.config.js
+++ b/tests/security/jest.config.js
@@ -132,9 +132,6 @@ module.exports = {
   // Reset modules between tests
   resetModules: true,
   
-  // Test result processor
-  testResultsProcessor: '<rootDir>/tests/security/utils/test-results-processor.js',
-  
   // Error on deprecated features
   errorOnDeprecated: true,
   


### PR DESCRIPTION
Closes ops #2279. Follow-up tracked as ops #2312.

All five root suites **collected but none could run**, each blocked by its own distinct pre-existing defect.

### Fixed
1. **e2e** — `global-setup.js` required `@jest/test-sequencer`, which is not installed, so the file could not load. Behind that, it exported an object where jest's `globalSetup` needs a bare function. Fixed both by **deleting the unused import** rather than adding a dependency. That exposed a third defect: `e2e-environment.js`/`github-simulator.js` export named `{Class}` objects, not bare classes.
2. **performance** — `globalSetup` ran `execSync('npm run db:reset')`; that script exists in neither manifest. **Chose to remove the call** rather than write it — writing it would decide these suites own a real DB+server lifecycle, a design call bigger than a blocker fix warrants.
3. **disaster-recovery** — reporter threw on a missing `./logo.png` before printing any summary. Set `logoImgPath: undefined`, matching the existing convention in the sibling configs.
4. **security** — `testResultsProcessor` was set **twice**: one pointing at a file that does not exist, one at `undefined`. The later key won, so the suite was protected purely by its own bug — **anyone tidying the duplicate without noticing would have broken it.** Deleted the *earlier* key, kept `undefined`.

### Honest state — these run, they do not pass
```
performance         18 tests execute, ALL 18 FAIL (real assertions
                    against a target that is not running)
e2e                 0 executed — reaches a real Postgres/MCP/API boot,
                    stops on missing infra
integration/DR/sec  0 executed — blocked on two out-of-scope modules
```
This is still an improvement: the failure surface moved from *"hides everything"* to *"shows exactly what is missing"*. **None of these suites is wired to CI, so no gate changes behaviour** — and ops #2312 tracks adding skip-if-infra-absent before anyone wires them, so main never goes permanently red.

### Out of scope
`tests/integration/setup/test-environment.js` and `api/repositories/deployment-repository.js` — the latter is a production class whose existence is an open design question given `scripts/services/database/deployment-repository.js` already does that job.

### Verification
No dependency drift — `git diff origin/main` on all four manifests is empty, dev or prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)