### PR TITLE
fix(webhook): fail CLOSED when no secret is configured — live 401 bypass on CT 123

### DIFF
--- a/api/services/webhook-handler.js
+++ b/api/services/webhook-handler.js
@@ -393,20 +393,29 @@ class WebhookHandler extends EventEmitter {
    * Verify webhook signature
    */
   verifySignature(payload, signature) {
-    if (!this.secret) {
-      console.warn('No webhook secret configured - skipping signature verification');
-      return true;
+    // FAIL CLOSED. This previously returned true when no secret was set,
+    // which made every unsigned request authentic. Measured on CT 123 on
+    // 2026-08-04: an unsigned POST returned 200 and was accepted for
+    // processing. "I cannot verify this" must never mean "this is fine".
+    if (!this.secret || !signature) {
+      return false;
     }
 
-    const expectedSignature = crypto
-      .createHmac('sha256', this.secret)
-      .update(payload)
-      .digest('hex');
-
-    return crypto.timingSafeEqual(
-      Buffer.from(`sha256=${expectedSignature}`, 'utf8'),
-      Buffer.from(signature, 'utf8')
+    const expected = Buffer.from(
+      `sha256=${crypto.createHmac('sha256', this.secret).update(payload).digest('hex')}`,
+      'utf8'
     );
+    const provided = Buffer.from(signature, 'utf8');
+
+    // timingSafeEqual THROWS on a length mismatch, which the caller's
+    // catch-all turned into a 500 -- a short or malformed header read as a
+    // server fault rather than a rejected request. Compare lengths first;
+    // the length of an HMAC-SHA256 hex digest is not a secret.
+    if (expected.length !== provided.length) {
+      return false;
+    }
+
+    return crypto.timingSafeEqual(expected, provided);
   }
 
   /**
@@ -430,8 +439,20 @@ class WebhookHandler extends EventEmitter {
         // middleware did not run.
         const payload = req.rawBody || JSON.stringify(req.body);
 
-        // Verify signature if secret is configured
-        if (this.secret && !this.verifySignature(payload, signature)) {
+        // Always verify. The old guard was `this.secret && !verify(...)`,
+        // which SHORT-CIRCUITED when no secret was configured and made the
+        // 401 branch unreachable -- so a missing secret silently disabled
+        // authentication instead of failing loudly.
+        if (!this.secret) {
+          console.error(
+            'GITHUB_WEBHOOK_SECRET is not configured - refusing webhook. ' +
+            'The endpoint cannot authenticate callers and will reject every ' +
+            'request until a secret is set.'
+          );
+          return res.status(401).json({ error: 'Invalid signature' });
+        }
+
+        if (!this.verifySignature(payload, signature)) {
           console.error('Invalid webhook signature');
           return res.status(401).json({ error: 'Invalid signature' });
         }

--- a/api/services/webhook/enhancedWebhookHandler.js
+++ b/api/services/webhook/enhancedWebhookHandler.js
@@ -40,9 +40,20 @@ class EnhancedWebhookHandler extends EventEmitter {
    * Verify webhook signature
    */
   verifySignature(payload, signature) {
+    // FAIL CLOSED. This returned true when no secret was configured, which
+    // made every unsigned request authentic. The same defect in
+    // services/webhook-handler.js was live on CT 123 on 2026-08-04 and
+    // accepted unauthenticated webhooks (ops #2524).
+    //
+    // This class is currently dead code -- nothing requires it -- but a
+    // fail-open verifier sitting unused is a loaded tripwire for whoever
+    // mounts it next, and it is cheaper to disarm than to remember.
     if (!this.secret) {
-      this.logger.warn('No webhook secret configured - skipping signature verification');
-      return true;
+      this.logger.error(
+        'No webhook secret configured - refusing webhook. Signature cannot ' +
+        'be verified, so the request is rejected rather than trusted.'
+      );
+      return false;
     }
 
     if (!signature) {

--- a/tests/unit/webhook-signature-rawbody.test.js
+++ b/tests/unit/webhook-signature-rawbody.test.js
@@ -106,6 +106,16 @@ describe('ops #2524 follow-up — webhook HMAC uses the raw bytes', () => {
     expect(payload).toEqual({ status: 'ok', event: 'push', delivery: 'deadbeef' });
   });
 
+  test('a MISSING signature is rejected 401, not 500', async () => {
+    // Buffer.from(undefined) throws inside timingSafeEqual, which the
+    // catch-all turned into a 500. A 500 reads as "server broke", not
+    // "you are not authorised", and ops #2524 acceptance item 3 wants a 401.
+    const raw = Buffer.from('{"zen":"Design for failure.","hook_id":1}', 'utf8');
+    const { statusCode, payload } = await invoke(handler, { rawBody: raw, signature: undefined });
+    expect(statusCode).toBe(401);
+    expect(payload).toEqual({ error: 'Invalid signature' });
+  });
+
   test('a genuinely wrong signature is still rejected 401', async () => {
     const raw = Buffer.from('{"zen":"Design for failure.","hook_id":1}', 'utf8');
     const { statusCode, payload } = await invoke(handler, {
@@ -135,5 +145,56 @@ describe('ops #2524 follow-up — webhook HMAC uses the raw bytes', () => {
     await handler.middleware()(req, res, () => {});
     expect(statusCode).toBe(200);
     expect(payload).toEqual({ status: 'ok', event: 'push', delivery: 'deadbeef' });
+  });
+});
+
+/**
+ * Measured on CT 123 immediately after ops #2524 deployed, 2026-08-04:
+ * GITHUB_WEBHOOK_SECRET is absent from the running process, so an
+ * unsigned POST to /api/v2/webhooks/github returned 200 {"status":"ok"}
+ * and the event was accepted for processing.
+ *
+ * Root cause: verifySignature() returned TRUE when no secret was set, and
+ * the caller's `this.secret && !verifySignature(...)` short-circuited, so
+ * the 401 branch was unreachable. A missing secret is a misconfiguration,
+ * and the safe response to "I cannot verify this" is to refuse it.
+ */
+describe('ops #2524 follow-up — no secret configured must FAIL CLOSED', () => {
+  let handler;
+
+  beforeEach(() => {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+    handler = new WebhookHandler({});          // no secret, as on CT 123
+    jest.spyOn(handler.webhooks, 'receive').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (handler?.eventQueue?.pause) handler.eventQueue.pause();
+    jest.restoreAllMocks();
+  });
+
+  test('an UNSIGNED request is refused, not accepted', async () => {
+    const raw = Buffer.from('{"zen":"Design for failure."}', 'utf8');
+    const { statusCode, payload } = await invoke(handler, { rawBody: raw, signature: undefined });
+    expect(statusCode).toBe(401);
+    expect(payload).not.toEqual({ status: 'ok', event: 'push', delivery: 'deadbeef' });
+  });
+
+  test('a request with ANY signature is refused when no secret is configured', async () => {
+    // Nothing can be verified against a secret that does not exist, so a
+    // well-formed-looking signature must not buy anything either.
+    const raw = Buffer.from('{"zen":"Design for failure."}', 'utf8');
+    const { statusCode } = await invoke(handler, {
+      rawBody: raw,
+      signature: `sha256=${'0'.repeat(64)}`,
+    });
+    expect(statusCode).toBe(401);
+  });
+
+  test('the webhook is never handed to the processor without a secret', async () => {
+    const raw = Buffer.from('{"zen":"Design for failure."}', 'utf8');
+    await invoke(handler, { rawBody: raw, signature: undefined });
+    // The status code alone would not prove the event was not enqueued.
+    expect(handler.webhooks.receive).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Live finding

Measured on CT 123 minutes after #205 deployed:

```
POST /api/v2/webhooks/github   no signature     -> 200 {"status":"ok"}
POST /api/v2/webhooks/github   bogus signature  -> 200 {"status":"ok"}
```

The endpoint accepted **unauthenticated** webhooks and handed them to the processor. `GITHUB_WEBHOOK_SECRET` is absent from the running process (verified value-free via `/proc/<pid>/environ`; no env file references it), and the listener is on `0.0.0.0:3070`.

Per ops #2524 this path is what `repository_dispatch`-driven deployments run through.

## Root cause — two parts, both required

1. `verifySignature()` returned **true** when `this.secret` was unset.
2. The caller guarded with `this.secret && !verifySignature(...)`, which **short-circuits** when there is no secret — making the 401 branch unreachable.

So a missing secret silently disabled authentication rather than failing loudly.

This is the fail-open flagged during review of #205 and recorded on ops #2524 **before** deploying. Predicting it did not stop it being live. Stated plainly: **#205 converted a broken-but-closed endpoint (400 on everything) into a working-but-open one**, and that trade should have been weighed before the merge.

## Fix

- `verifySignature()` returns `false` when the secret **or** the signature is missing.
- `middleware()` checks `!this.secret` explicitly and 401s with a loud log.
- `timingSafeEqual` length mismatch guarded — it throws on unequal lengths, which the catch-all turned into a **500**, so a short/malformed `X-Hub-Signature-256` read as a server fault rather than a rejection. This also closes **ops #2524 acceptance item 3** (missing signature → 401).

## Fire-tested

The four new tests were **RED against the deployed code** and reproduce the live CT 123 behaviour exactly:

```
✕ a MISSING signature is rejected 401, not 500
✕ an UNSIGNED request is refused, not accepted
✕ a request with ANY signature is refused when no secret is configured
✕ the webhook is never handed to the processor without a secret
```

12/12 pass across both webhook suites after. The last of those asserts `webhooks.receive()` was never called — a status code alone would not prove the event wasn't enqueued.

## Deliberate behaviour change

Until `GITHUB_WEBHOOK_SECRET` is set on CT 123, this endpoint returns **401 to everything**. That is the same closed posture it had before #205 (which returned 400 to everything), and it is the correct direction for an endpoint that cannot authenticate callers.

**Not done / unverified:** the secret itself is not set — a credential operation for the operator, and it must match the secret configured on the GitHub webhook. Whether `:3070` is reachable beyond the LAN is **unverified**; Traefik's API did not answer from CT 128, so exposure should not be assumed LAN-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)