### PR TITLE
fix(mcp-servers): gate the fourth workspace and clear its 3 high advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
     - name: Validate package.json (Dashboard)
       run: ./scripts/ci-audit-gate.sh dashboard high
 
+    # mcp-servers/ is a first-party workspace (59 tracked files, its own
+    # lockfile) that was NEVER gated. It silently accumulated the same three
+    # highs the other workspaces were carrying, and they only surfaced because
+    # Trivy's fs scan walks the whole tree (ops #2296).
+    - name: Validate package.json (mcp-servers)
+      run: ./scripts/ci-audit-gate.sh mcp-servers high
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -336,6 +343,9 @@ jobs:
 
     - name: Run dependency audit (Dashboard)
       run: ./scripts/ci-audit-gate.sh dashboard high
+
+    - name: Run dependency audit (mcp-servers)
+      run: ./scripts/ci-audit-gate.sh mcp-servers high
         
     # The two "Check for critical vulnerabilities" steps that used to sit here
     # were removed. They gated on `.metadata.vulnerabilities.high + .critical`

--- a/mcp-servers/package-lock.json
+++ b/mcp-servers/package-lock.json
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -501,9 +501,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -729,9 +729,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/mcp-servers/package.json
+++ b/mcp-servers/package.json
@@ -23,6 +23,9 @@
     "glob": "^11.0.0",
     "rimraf": "^6.0.0",
     "path-to-regexp": "^8.4.0",
-    "hono": "^4.12.31"
+    "hono": "^4.12.31",
+    "brace-expansion": "^5.0.9",
+    "fast-uri": "^3.1.5",
+    "ip-address": "^10.3.1"
   }
 }


### PR DESCRIPTION
## An unaudited workspace

`mcp-servers/` is a **first-party npm workspace** in this repo — 59 tracked files, no `.git`, no submodule, its own 48 KB lockfile — and **nothing has ever audited it**. Enumerated from the workflows rather than assumed:

```
ci.yml            ci-audit-gate.sh {., api, dashboard} high   (x2 jobs)
gitops-audit.yml  ci-audit-gate.sh {dashboard, api} moderate

package.json present: ./  ./api  ./dashboard  ./mcp-servers   <- never gated
```

It could accumulate high/critical advisories indefinitely with no gate ever going red. It had silently collected **the same three highs #205 fixed everywhere else today**:

| Package | Advisory | Now |
|---|---|---|
| brace-expansion | GHSA-rgw5-rvv9-x895 | `^5.0.9` |
| fast-uri | GHSA-7p8r-x3mc-p8w7 | `^3.1.5` |
| ip-address | GHSA-mwp4-54f8-5fhr | `^10.3.1` |

## How it surfaced

Via ops #2296: **6 of the 8** open code-scanning findings appeared *today*, and **5 point at `mcp-servers/package-lock.json`**. They were visible only because Trivy's fs scan walks the whole tree — which cuts directly against that card's "Trivy contributes zero unique signal" conclusion. Trivy was compensating for a coverage hole nobody knew about.

## Fire-tested

Transition observed, not asserted:

```
before   [mcp-servers] 3 high advisories, not allowlisted   rc=1
after    [mcp-servers] npm audit clean at level 'high'      rc=0
```

Gate wired into **both** `ci.yml` jobs, matching the other three workspaces, so this cannot regress silently again.

## Deliberately NOT fixed — the four moderates

One needs a **major** bump:

- `ip-address` GHSA-22jq-vg5j-6vgg / GHSA-4xrf-jv44-h6hh — already covered by `^10.3.1`
- `hono` GHSA-8j4g-w8fx-2239 — patched 4.12.34, override is `^4.12.31`
- `@hono/node-server` GHSA-frvp-7c67-39w9 — patched **2.0.5**, installed line is **1.x**. There is no 1.x fix, so this is a major bump.

A major bump behind an `overrides` entry is the same risk class as `npm audit fix --force`, and I have not established that `mcp-servers`' test script exercises the hono path. Gating at `high` matches `ci.yml`'s treatment of the repo root and does not block on these. Raising to `moderate` should wait until the hono upgrade is tested on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)