### PR TITLE
ci: skip the four non-required workflows on docs-only changes (ops #2616)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,8 +3,18 @@ name: Code Quality Check
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gitops-audit.yml
+++ b/.github/workflows/gitops-audit.yml
@@ -3,8 +3,18 @@ name: GitOps Audit and Quality Check
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   schedule:
     # Run daily at 3:00 AM UTC
     - cron: '0 3 * * *'

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -3,8 +3,18 @@ name: Enhanced Security Scanning
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   schedule:
     - cron: '0 2 * * 1' # Weekly on Monday
   workflow_dispatch:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,8 +3,18 @@ name: Security Scan
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**/*.md'
+      - '.claude/**'
+      - '.serena/**'
+      - 'docs/**'
   schedule:
     # Run security scan daily at 2 AM UTC
     - cron: '0 2 * * *'


### PR DESCRIPTION
Split out of #210 so the docs trim and the CI change land separately.

## The problem

A CLAUDE.md-only PR fans out **7 workflows and ~15 jobs** here. On #210 that overflowed whatever runner budget applies — five jobs across `Continuous Integration` and `Code Quality Check` sat until a 15-minute ceiling and were killed:

```
The job was not acquired by Runner of type hosted even after multiple attempts
```

No test ever ran. But `Unit Tests` is a required check, so the PR went `BLOCKED` with nothing wrong in the diff.

Worth noting for whoever hits this next: **the failure is indistinguishable from a real test failure at a glance.** `Unit Tests=CANCELLED` on a red PR reads as "the tests broke", and the reflex is to go debug the tests. The annotation naming the runner is one click deeper than the check list.

## What this does

Adds `paths-ignore` (`**/*.md`, `.claude/**`, `.serena/**`, `docs/**`) to the four workflows that are **not** required checks:

`code-quality.yml` · `gitops-audit.yml` · `security-scan.yml` · `security-enhanced.yml`

A docs-only PR now runs **2 workflows instead of 6** — cutting both the job count competing for runners and the paid minutes a docs commit burns.

## What it deliberately does NOT do

**`ci.yml` and `lint-and-test.yml` are untouched**, and that is the whole design of this change rather than an oversight.

They carry the two required checks (`Unit Tests`, `lint-and-test (20.x)`). **GitHub treats a required check skipped by a path filter as permanently pending, not as passed.** Filtering those would have converted a slow merge into an impossible one: every future docs-only PR stuck at *"Expected — Waiting for status to be reported"*, unmergeable without editing branch protection.

So the contention relief has to come from the non-required workflows or not at all.

## Ruled out before writing this

- **Not the diff** — #210 changed CLAUDE.md only.
- **Not the chronic redness** of ops #2271/#2279/#2312 — both workflows passed on the last four merged PRs (#205, #206, #208, #209).
- **Not exhausted Actions minutes** — `Lint and Test`, `Security Scan` and two others succeeded on the same push; starvation would have taken those too.
- **Not a runner-label mismatch** — `ci.yml`, `code-quality.yml` and `lint-and-test.yml` all declare `runs-on: ubuntu-latest`. Same label, opposite outcomes.

The leading hypothesis is a concurrent-job cap, **unconfirmed**: `orgs/festion/actions/runners` and both billing endpoints return 403 for the current PAT. Confirming needs a billing-scoped token or the Actions usage page.

## Verification

All six PR-triggered workflows still parse; the four intended files carry `paths-ignore` and the two required ones do not:

```
ci.yml                  pr-trigger  paths-ignore=no    <- required
code-quality.yml        pr-trigger  paths-ignore=YES
gitops-audit.yml        pr-trigger  paths-ignore=YES
lint-and-test.yml       pr-trigger  paths-ignore=no    <- required
security-enhanced.yml   pr-trigger  paths-ignore=YES
security-scan.yml       pr-trigger  paths-ignore=YES
```

**The effect cannot be observed on this PR** — it touches `.github/**`, which is not in the ignore list, so everything runs here as it should. It pays off on the next docs-only change.

Precedent: `home-assistant-config` already excludes `.claude/**`, `docs/**` and `CLAUDE.md` from its push trigger for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)