### PR TITLE
fix(deps): bump js-yaml to patched 3.15.1/4.3.1 — unblocks CI on main (ops #2629)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1808,9 +1808,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7087,9 +7087,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9245,9 +9245,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Bumps `js-yaml` to its patched releases in all three lockfiles. Lockfile-only: 12 lines, no `package.json` change.

## Why

CI has been red on `main` since GHSA-5p4m-2wfm-xmqj appeared. The npm-audit gate failed in `.`, `api` **and** `dashboard`, putting every open PR at `mergeStateStatus=UNSTABLE`.

**The advisory summary is misleading.** It reads *"CVE-2026-59870 fix not backported"*, which reads like an unfixable advisory and invites an `audit-allowlist.json` entry. The advisory record itself says otherwise — both affected lines have a patched release:

| vulnerable range | first patched |
|---|---|
| `>= 4.0.0, < 4.3.1` | **4.3.1** |
| `>= 3.0.0, < 3.15.1` | **3.15.1** |

So this needed a bump, not an exception. **No allowlist entry was added** — that mechanism is for when there is genuinely no patch, and here there is one.

## Why it's a clean bump

Every dependent already declares a range that accepts the patch:

| dependent | range | resolves to |
|---|---|---|
| `@istanbuljs/load-nyc-config` (all 3 dirs) | `^3.13.1` | 3.15.0 → **3.15.1** |
| `eslint`, `@eslint/eslintrc` (dashboard) | `^4.1.0` | 4.3.0 → **4.3.1** |
| `api` / `dashboard` roots | `^4.1.1` | → **4.3.1** |

`npm update js-yaml --package-lock-only`. No overrides, no major migration, no `npm audit fix --force`.

## Verification

Ran the gate script against both states and read **its own exit code**, not a pipeline's:

```
before (origin/main)   .=rc1  api=rc1  dashboard=rc1  mcp-servers=rc0
after                  .=rc0  api=rc0  dashboard=rc0  mcp-servers=rc0
```

The `before` failures reproduce CI's exact error string, so the control is the real thing and not a lookalike. `dashboard` passes with its pre-existing react-router allowlist entry (GHSA-qwww-vcr4-c8h2, ops #2261) still in force and unexpired — this PR does not touch or extend it. The `moderate` level that `gitops-audit.yml` uses for `api` and `dashboard` also passes.

Diff contains only `version` / `resolved` / `integrity` lines for js-yaml — no other package moved.

## Note

This should also unblock PR #215 and the 6 open dependabot PRs, which were failing on this same gate rather than on their own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)