### PR TITLE
security: stop the compliance engine demanding a tracked .mcp.json (ops #2628)

### DIFF
--- a/.mcp/templates/standard-devops/gitignore.template
+++ b/.mcp/templates/standard-devops/gitignore.template
@@ -23,3 +23,10 @@ venv/
 *.backup
 *.tmp
 backups/
+
+# Project-scope MCP config (ops #2628). Holds per-machine absolute paths and an
+# inline `env` block / docker `-e NAME=value` args -- i.e. credentials. Commit
+# `.mcp.json.example` with placeholders instead; this is the file a developer
+# fills in with real values, and it is how a live Home Assistant token reached
+# a PUBLIC repo's git history (ops #2625).
+.mcp.json

--- a/.mcp/templates/standard-devops/template.json
+++ b/.mcp/templates/standard-devops/template.json
@@ -12,7 +12,7 @@
   },
   "files": [
     {
-      "path": ".mcp.json",
+      "path": ".mcp.json.example",
       "type": "merge",
       "source": "mcp-config.json",
       "merge_strategy": "merge_json",
@@ -43,7 +43,7 @@
     }
   ],
   "compliance": {
-    "required_files": [".mcp.json", "CLAUDE.md"],
+    "required_files": [".mcp.json.example", "CLAUDE.md"],
     "required_directories": ["scripts"],
     "scoring_weights": {
       "files": 0.6,

--- a/api/services/compliance/templateEngine.js
+++ b/api/services/compliance/templateEngine.js
@@ -287,17 +287,28 @@ class TemplateEngine {
       }));
     }
 
-    // Check for MCP configuration
+    // Check for MCP configuration.
+    //
+    // This deliberately looks for `.mcp.json.example`, NOT `.mcp.json` (ops #2628).
+    // A project-scope `.mcp.json` carries an inline `env` block and docker
+    // `-e NAME=value` args, i.e. credentials, and it is the file a developer
+    // fills in with real ones. Telling every audited repo to "add .mcp.json"
+    // -- at HIGH severity -- pressures them into tracking exactly that. A real
+    // Home Assistant token reached a PUBLIC repo's history this way (ops #2625).
+    // The committed artifact is the example; the live config stays gitignored.
     if (template.requirements.mcp) {
-      const mcpConfig = path.join(repositoryPath, '.mcp.json');
-      if (!(await this.fileExists(mcpConfig))) {
+      const hasExample = await this.fileExists(path.join(repositoryPath, '.mcp.json.example'));
+      // A local (gitignored) .mcp.json also satisfies the requirement -- the repo
+      // is demonstrably MCP-configured. We just never ask for one to be added.
+      const hasLocal = await this.fileExists(path.join(repositoryPath, '.mcp.json'));
+      if (!hasExample && !hasLocal) {
         issues.push(new ComplianceIssue({
           type: ComplianceIssueType.MISSING,
           template: template.id,
-          file: '.mcp.json',
+          file: '.mcp.json.example',
           severity: ComplianceSeverity.HIGH,
-          description: 'MCP configuration file missing',
-          recommendation: 'Add .mcp.json configuration file'
+          description: 'MCP configuration example missing',
+          recommendation: 'Add a .mcp.json.example with placeholder values, and keep the real .mcp.json gitignored'
         }));
       }
     }

--- a/api/tests/services/templateEngine.mcpconfig.test.js
+++ b/api/tests/services/templateEngine.mcpconfig.test.js
@@ -1,0 +1,73 @@
+// ops #2628: the MCP compliance check must never pressure a repository into
+// TRACKING a `.mcp.json`.
+//
+// A project-scope `.mcp.json` carries an inline `env` block and docker
+// `-e NAME=value` args -- credentials -- and it is the file a developer fills
+// in with real ones. The old check reported a missing `.mcp.json` as a HIGH
+// severity issue with the recommendation "Add .mcp.json configuration file",
+// which is precisely the shape that put a live Home Assistant long-lived token
+// into a PUBLIC repo's git history (ops #2625).
+//
+// The requirement is now satisfied by a committed `.mcp.json.example` (or by a
+// local, gitignored `.mcp.json`), and the recommendation must never name a bare
+// `.mcp.json` as the thing to add.
+
+const os = require('os');
+const path = require('path');
+const fs = require('fs').promises;
+
+const TemplateEngine = require('../../services/compliance/templateEngine');
+
+const TEMPLATE = { id: 'standard-devops', requirements: { git: false, mcp: true } };
+
+describe('TemplateEngine MCP config compliance (#2628)', () => {
+  let engine;
+  let repoDir;
+
+  beforeEach(async () => {
+    engine = new TemplateEngine();
+    repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcpcompliance-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(repoDir, { recursive: true, force: true });
+  });
+
+  const mcpIssues = async (template = TEMPLATE) => {
+    const issues = await engine.checkCustomCompliance(repoDir, template);
+    return issues.filter((i) => String(i.file).includes('.mcp.json'));
+  };
+
+  it('is satisfied by a committed .mcp.json.example', async () => {
+    await fs.writeFile(path.join(repoDir, '.mcp.json.example'), '{"mcpServers":{}}');
+    expect(await mcpIssues()).toHaveLength(0);
+  });
+
+  it('is satisfied by a local (gitignored) .mcp.json', async () => {
+    await fs.writeFile(path.join(repoDir, '.mcp.json'), '{"mcpServers":{}}');
+    expect(await mcpIssues()).toHaveLength(0);
+  });
+
+  it('raises exactly one issue when neither file is present', async () => {
+    expect(await mcpIssues()).toHaveLength(1);
+  });
+
+  // The security-relevant assertion: WHAT the check asks for, not merely THAT
+  // it fired. A check that fires but still says "add .mcp.json" is the bug.
+  it('never asks the repository to add a tracked .mcp.json', async () => {
+    const [issue] = await mcpIssues();
+
+    expect(issue.file).toBe('.mcp.json.example');
+    expect(issue.file).not.toBe('.mcp.json');
+
+    // The recommendation must point at the example, and must not read as an
+    // instruction to create a bare .mcp.json.
+    expect(issue.recommendation).toMatch(/\.mcp\.json\.example/);
+    expect(issue.recommendation).not.toMatch(/add\s+(a\s+)?\.mcp\.json(?!\.example)/i);
+  });
+
+  it('raises nothing when the template does not require MCP', async () => {
+    const noMcp = { id: 'standard-devops', requirements: { git: false, mcp: false } };
+    expect(await mcpIssues(noMcp)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Follow-up to ops #2625, where a real Home Assistant long-lived token reached this **public** repo's history inside a tracked `.mcp.json`. This closes the thing that would ask for that file again.

## First, a correction to the premise

Task #2628 claimed the `standard-devops` template *manufactures* tracked `.mcp.json` files in every repo it touches. **That is wrong, and worth stating plainly** — the applicator cannot write anything:

```python
def apply_template(self, template_path, repo_path):
    if self.dry_run:
        return self.apply_template_dry_run(...)
    # This would be the actual implementation for applying changes
    return self.apply_template_dry_run(...)
```

Both branches return the dry-run plan, so `--apply` writes nothing and never has. `compliance.required_files` is dead config too — nothing reads it; only the docs echo it back. The `.mcp.json` files found across five repos in #2625 got there by hand, not from this template.

## What is actually live

`checkCustomCompliance` raised a **HIGH** severity issue — *"MCP configuration file missing / Add .mcp.json configuration file"* — for every audited repo without one. That path is mounted: `createApp.js` → `phase2Router` → `/api/v2/compliance/*`. A project-scope `.mcp.json` holds an inline `env` block and docker `-e NAME=value` args, so the recommendation pushes repos toward tracking credentials.

**It is latent, not active.** Production cannot load the template at all:

```
GET /api/v2/compliance/repository/home-assistant-config
  → "Template check failed: Template not found: standard-devops"
GET /api/v2/compliance/templates
  → {"templates":[],"total":0}
```

`templatesDir` resolves under `projectRoot/.mcp`, which the deployed tree lacks. That is precisely why this is worth fixing now — whoever repairs the template deployment would otherwise silently switch the bad recommendation on, with no diff that mentions `.mcp.json`.

## Changes

| file | change |
|---|---|
| `templateEngine.js` | requirement satisfied by `.mcp.json.example`, or by a local (gitignored) `.mcp.json`; never names a bare `.mcp.json` as the thing to add |
| `template.json` | ships `.mcp.json.example`; `required_files` follows |
| `gitignore.template` | excludes `.mcp.json`, reason inline |

## Tests

New `api/tests/services/templateEngine.mcpconfig.test.js`. **Fire-tested** — reverting only the engine change turns **2 of the 5 red**, including the one that asserts on *what the check asks for* rather than merely *that it fired*:

```
✕ is satisfied by a committed .mcp.json.example
✓ is satisfied by a local (gitignored) .mcp.json
✓ raises exactly one issue when neither file is present
✕ never asks the repository to add a tracked .mcp.json
✓ raises nothing when the template does not require MCP
```

The 3 that stay green do not discriminate between old and new behaviour — they pin the edges. Saying so matters: a suite where every test passes against the old code is testing nothing.

Full api suite green: **19 suites, 186 tests**.

## Found while verifying, filed separately

- **ops #2630** — repo-root `node_modules` pairs `test-exclude@6.0.0` (declares `minimatch@^3.0.4`) with hoisted `minimatch@10.2.4`, whose export is an object. Running api tests without `api/node_modules` dies with `minimatch is not a function` pointing at `api/models/database.js` — a file that never executes.
- **ops #2631** — `jest.config.js` defines `projects[]`, which overrides the top-level `testMatch`. The `'<rootDir>/test/**/*.test.js'` entry is dead: **11 test files in `api/test/` have never run**, including an 18 KB `compliance-service.test.js`. `npx jest --listTests` returns 19 files, all under `tests/`.

Neither is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)