### PR TITLE
security: drop the literal `:-` default from the MCP template (ops #2628)

### DIFF
--- a/.mcp/templates/standard-devops/mcp-config.json
+++ b/.mcp/templates/standard-devops/mcp-config.json
@@ -29,7 +29,7 @@
         "-i",
         "--rm",
         "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-your_github_token_here}",
+        "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}",
         "ghcr.io/github/github-mcp-server"
       ]
     }

--- a/api/tests/services/templates.noInlineSecrets.test.js
+++ b/api/tests/services/templates.noInlineSecrets.test.js
@@ -1,0 +1,72 @@
+// ops #2628: a shipped template must never carry a literal default for an
+// environment reference.
+//
+// `.mcp/templates/standard-devops/mcp-config.json` shipped
+//
+//     "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-<literal>}"
+//
+// which READS as env indirection but is an inline value wearing a `${}`. The
+// shell substitutes the literal whenever the variable is unset, so the config
+// is credential-bearing by default and only accidentally safe when the
+// environment happens to be populated. This is the same defect as ops #2310
+// (`SPOTIFY_CLIENT_SECRET` committed as a hardcoded `:-` fallback in dotfiles).
+//
+// PR #217 changed where the template lands (`.mcp.json.example`, gitignoring
+// `.mcp.json`). It did not change what the template TEACHES: whoever fills the
+// example in replaces a placeholder default with a real one, in a file whose
+// whole shape says defaults belong here.
+//
+// The ban is deliberately BLANKET rather than keyed on credential-shaped
+// variable names. A name list only catches the secrets someone thought of --
+// `access_token`, `network_key` and `tunnel_secret` all sail past a
+// TOKEN|SECRET|KEY pattern in the wild. Default to rejecting every literal
+// default; add to ALLOWED_DEFAULTS, with a reason, if a genuinely non-secret
+// one is ever needed.
+
+const path = require('path');
+const fs = require('fs');
+
+const TEMPLATES_DIR = path.resolve(__dirname, '../../../.mcp/templates');
+
+// `${NAME:-default}` and `${NAME:=default}` -- both substitute the literal.
+const LITERAL_DEFAULT = /\$\{([A-Za-z_][A-Za-z0-9_]*):[-=]([^}]*)\}/g;
+
+// Deliberately empty. An entry is `${NAME:-value}` verbatim plus a comment
+// explaining why that value can never be a credential.
+const ALLOWED_DEFAULTS = [];
+
+const walk = (dir) =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = path.join(dir, e.name);
+    return e.isDirectory() ? walk(full) : [full];
+  });
+
+describe('shipped templates carry no inline secret defaults (#2628)', () => {
+  // If the templates directory ever moves, this suite would silently pass by
+  // scanning nothing -- the reassuring direction. Pin it.
+  it('finds the templates directory and at least one template file', () => {
+    expect(fs.existsSync(TEMPLATES_DIR)).toBe(true);
+    expect(walk(TEMPLATES_DIR).length).toBeGreaterThan(0);
+  });
+
+  it('no template file uses a literal default for an env reference', () => {
+    const offenders = [];
+
+    for (const file of walk(TEMPLATES_DIR)) {
+      const rel = path.relative(TEMPLATES_DIR, file);
+      const text = fs.readFileSync(file, 'utf8');
+
+      for (const m of text.matchAll(LITERAL_DEFAULT)) {
+        if (ALLOWED_DEFAULTS.includes(m[0])) continue;
+        // Report the variable NAME and the default's length only. The whole
+        // point of the finding is that the default may be a live credential,
+        // so a failure message must not print it.
+        offenders.push(
+          `${rel}: \${${m[1]}:-...} (default length ${m[2].length})`
+        );
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Completes **ops #2628**. PR #217 closed the "compliance engine demands a tracked `.mcp.json`" half and correctly rejected the card's premise (the applicator writes nothing). This closes the half that survived it.

## The defect

`.mcp/templates/standard-devops/mcp-config.json` shipped:

```
"GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-<literal>}"
```

That reads as env indirection but is an inline value wearing a `${}`. The shell substitutes the literal whenever the variable is unset, so the config is credential-bearing **by default** and only accidentally safe when the environment happens to be populated. Same defect as ops #2310 (`SPOTIFY_CLIENT_SECRET` as a hardcoded `:-` fallback in dotfiles).

#217 changed *where* this lands (`.mcp.json.example`, with `.mcp.json` gitignored) but not what it *teaches* — whoever fills the example in replaces a placeholder default with a real one, in a file whose whole shape says defaults belong here.

## The removed literal was not a credential

Worth stating precisely, because the card is imprecise. ops #2628 records "the placeholder GH PAT (sha16 `e5fa2ac3fa1c0d1a`)" — but that hash is of the **entire `${...}` expression**, not of the default. Measured directly, the default is 22 chars, lowercase + underscore only, 4 underscore-separated words, matching neither `ghp_[A-Za-z0-9]{36}` nor `github_pat_…` (sha16 `a427bc6b187488ae`). A human-readable placeholder. Consistent with the card's 401 capability test, but **no live value ever sat here**. The shape is the finding, not the contents.

## Changes

- `mcp-config.json`: `${NAME:-literal}` → `${NAME}`. The only occurrence in `.mcp/` — both templates swept.
- `api/tests/services/templates.noInlineSecrets.test.js`: scans every shipped template file for `${NAME:-default}` / `${NAME:=default}`.

The ban is **blanket**, not keyed on credential-shaped variable names. A name list only catches the secrets someone thought of — `access_token`, `network_key` and `tunnel_secret` all sail past a `TOKEN|SECRET|KEY` pattern. Empty `ALLOWED_DEFAULTS` is the escape hatch. The failure message prints the variable name and the default's **length**, never the default.

The suite also pins that it found the templates directory and a non-zero file count — if `.mcp/templates` ever moves, it would otherwise pass by scanning nothing, which is the reassuring direction.

## Verification

**Fire-tested.** Committed first, then re-injected `${GITHUB_PERSONAL_ACCESS_TOKEN:-injected_fire_test_value}` and confirmed the guard goes red, reporting `${GITHUB_PERSONAL_ACCESS_TOKEN:-...} (default length 24)` — name and length, no value. Restored from a `cp` backup (not `git checkout`), re-ran with `--no-cache`, and asserted against the **loaded** value rather than the file's.

Full api suite green: **20 suites, 188 tests**.

## Closing the card's stated unverified item

ops #2628 carried: *"I did not enumerate which repos the applicator has actually been run against, nor whether any non-workspace repo received a `.mcp.json` from it."*

1. **The applicator cannot write** — verified independently rather than taken from #217: `apply_template()` returns `apply_template_dry_run()` on both branches, and the whole file holds 3 read-mode `open()`s plus one `git status --porcelain`. No write, copy, or mkdir path exists. Nothing ever received a `.mcp.json` from it.
2. **Org-wide sweep, all 50 `festion` repos**, `.mcp.json` at default-branch HEAD: **3 track one** — `homelab-project-template` (private), `netbox-agent` (public, archived), `birdnet-go` (public). All three parsed structurally (names + lengths + sha16, no value read): every credential leaf is a pure `${VAR}` reference. **Zero literal defaults, zero bare literals.** `birdnet-go`'s has no credential leaf at all.

Sweep ran with a **positive control** through the identical predicate (a path known to exist on `homelab-gitops` main → `size=764`), because a contents-API sweep that silently matches nothing is indistinguishable from a clean result. First run of this sweep was wrong in the other direction — `gh api` prints the 404 body to stdout, so every repo read as a hit until the predicate was tightened to `size=`.

## Not done / deferred / unverified

- Sweep covers **default-branch HEAD only** — not full history (that is ops #2625's domain) and **not other branches**. A stale local `homelab-gitops` branch (`chore/remove-stale-duplicate-skills`) still carries the pre-#215 tracked `.mcp.json`; local-only, not pushed as a default branch.
- The template still hardcodes another machine's WSL layout (`/mnt/c/GIT/serena`, `/mnt/c/Users/Jeremy/OneDrive/Desktop`). Out of scope here; filed separately.
- `apply_template()` logs `"Applying template to repository"` and then returns a dry run — an `--apply` that reports success and changes nothing. Not touched here; filed separately.
- The compliance-engine path remains **latent in production** (templates dir absent from the deployed tree), exactly as #217 recorded. Unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
