### PR TITLE
fix(api): repoint services/orchestrator at the logger factory that exists (ops #2653)

### DIFF
--- a/api/services/orchestrator/dependencyAnalyzer.js
+++ b/api/services/orchestrator/dependencyAnalyzer.js
@@ -1,4 +1,4 @@
-const { createLogger } = require('../../config/logging');
+const { createLogger } = require('../../utils/logger');
 const fs = require('fs').promises;
 const path = require('path');
 

--- a/api/services/orchestrator/failureRecoveryService.js
+++ b/api/services/orchestrator/failureRecoveryService.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-const { createLogger } = require('../../config/logging');
+const { createLogger } = require('../../utils/logger');
 
 class FailureRecoveryService extends EventEmitter {
   constructor(orchestrator, options = {}) {

--- a/api/services/orchestrator/index.js
+++ b/api/services/orchestrator/index.js
@@ -3,7 +3,7 @@ const DependencyAnalyzer = require('./dependencyAnalyzer');
 const TaskExecutionEngine = require('./taskExecutionEngine');
 const OrchestrationMonitor = require('./orchestrationMonitor');
 const FailureRecoveryService = require('./failureRecoveryService');
-const { createLogger } = require('../../config/logging');
+const { createLogger } = require('../../utils/logger');
 
 class OrchestrationService {
   constructor(services = {}) {

--- a/api/services/orchestrator/orchestrationMonitor.js
+++ b/api/services/orchestrator/orchestrationMonitor.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-const { createLogger } = require('../../config/logging');
+const { createLogger } = require('../../utils/logger');
 const fs = require('fs').promises;
 const path = require('path');
 

--- a/api/services/orchestrator/pipelineOrchestrator.js
+++ b/api/services/orchestrator/pipelineOrchestrator.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-const { createLogger } = require('../../config/logging');
+const { createLogger } = require('../../utils/logger');
 
 class PipelineOrchestrator extends EventEmitter {
   constructor(services) {

--- a/api/services/orchestrator/taskExecutionEngine.js
+++ b/api/services/orchestrator/taskExecutionEngine.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-const { createLogger } = require('../../config/logging');
+const { createLogger } = require('../../utils/logger');
 const DependencyAnalyzer = require('./dependencyAnalyzer');
 
 class TaskExecutionEngine extends EventEmitter {

--- a/api/tests/services/orchestrator.logger.test.js
+++ b/api/tests/services/orchestrator.logger.test.js
@@ -1,0 +1,87 @@
+// ops #2653: every module in services/orchestrator/ must be able to construct.
+//
+// All six destructured `createLogger` from `config/logging`, which exports
+// `getComponentLogger` and no `createLogger` at all. Destructuring a missing
+// export is silent -- it yields `undefined` -- so `require` succeeded, the app
+// booted green, and the TypeError waited until a constructor ran, i.e. until an
+// orchestration endpoint was actually used. The subsystem is mounted:
+// createApp.js -> /api/v2 -> phase2-endpoints.js -> services/orchestrator.
+//
+// Nothing observed it for over a year because the only suites that exercise
+// these modules (test/orchestrator.test.js, test/coordination.test.js,
+// test/monitoring.test.js) are three of the eleven files that have never run --
+// api/jest.config.js declares `projects[]`, which shadows the top-level
+// testMatch that claims to collect `test/`. See ops #2631.
+//
+// This test lives under tests/ precisely so that it DOES run.
+//
+// It asserts on construction rather than on the import site. A future refactor
+// may legitimately move the logger factory or add `createLogger` to
+// config/logging; what must never come back is a module in this directory that
+// throws when instantiated.
+
+const fs = require('fs');
+const path = require('path');
+const { EventEmitter } = require('events');
+
+const ORCH_DIR = path.join(__dirname, '../../services/orchestrator');
+
+const modules = fs
+  .readdirSync(ORCH_DIR)
+  .filter((f) => f.endsWith('.js'))
+  .sort();
+
+// Some constructors wire event listeners onto what they are handed. An
+// EventEmitter satisfies that without pulling in the real orchestrator.
+const stubArg = () => {
+  const e = new EventEmitter();
+  e.github = {};
+  e.config = {};
+  return e;
+};
+
+const firstConstructor = (m) => {
+  if (typeof m === 'function') return m;
+  if (m && typeof m.default === 'function') return m.default;
+  return m && Object.values(m).find((v) => typeof v === 'function');
+};
+
+describe('services/orchestrator modules construct (#2653)', () => {
+  // If the directory moves or empties, every it.each below silently vanishes
+  // and the suite passes by testing nothing -- the reassuring direction.
+  it('finds the orchestrator modules', () => {
+    expect(modules.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(modules)('%s requires without throwing', (file) => {
+    expect(() => require(path.join(ORCH_DIR, file))).not.toThrow();
+  });
+
+  // The actual regression. A missing logger factory surfaces here and nowhere
+  // earlier, because destructuring an absent export is silent.
+  it.each(modules)('%s constructs without a missing-factory TypeError', (file) => {
+    const Ctor = firstConstructor(require(path.join(ORCH_DIR, file)));
+    if (!Ctor) return; // module exports no constructor; nothing to instantiate
+
+    let err = null;
+    try {
+      new Ctor(stubArg());
+    } catch (e) {
+      err = e;
+    }
+
+    // Deliberately narrow: other constructor-argument complaints are not this
+    // bug, and asserting "never throws at all" would make the test brittle
+    // against unrelated required-arg changes.
+    if (err) {
+      expect(err.message).not.toMatch(/is not a function/);
+      expect(err.message).not.toMatch(/is not a constructor/);
+    }
+  });
+
+  it('the logger factory the orchestrator imports is callable', () => {
+    const { createLogger } = require('../../utils/logger');
+    expect(typeof createLogger).toBe('function');
+    expect(createLogger('ops-2653-probe')).toBeDefined();
+  });
+});


### PR DESCRIPTION
The entire `api/services/orchestrator/` subsystem throws on construction, and has since 2025-07-19. Found while closing ops #2631's *"do the never-run suites pass?"* item — this is the first step of that card's option (a).

## The defect

All six modules did:

```js
const { createLogger } = require('../../config/logging');
...
this.logger = createLogger('<name>');
```

but `config/logging.js` exports `getComponentLogger` and **no `createLogger` at all**.

Destructuring a missing export is silent — it yields `undefined` — so `require()` succeeded, `createApp.js` loaded fine, and the `TypeError` waited until a constructor ran. Reproduced with no test harness, no mocks, no DI:

```
$ node -e "const D=require('./services/orchestrator/dependencyAnalyzer'); new D({})"
TypeError: createLogger is not a function
```

**It is mounted.** `createApp.js:100` mounts `phase2Router` at `/api/v2`; `phase2-endpoints.js` requires both `./services/orchestrator` (:2132) and `./routes/orchestration` (:2155). This is the latent-crash shape — boot is green, the route dies on first use.

## The fix

`utils/logger.js` is the factory that exists, and the one already used across `services/` — `mcp-coordinator`, `monitoring/*`, `webhook/*`, `deployment-orchestrator`, 10+ files. Its signature `createLogger(component, options = {})` is exactly how the orchestrator calls it. `config/logging.js` wraps that same factory internally inside `getComponentLogger`, which only `routes/webhooks.js` uses.

So the import was pointed at the wrong one of two logger modules. One line per file, six files.

## Why nothing caught it

The suites that exercise these modules — `test/orchestrator.test.js`, `test/coordination.test.js`, `test/monitoring.test.js` — are three of the **eleven files that have never run** (ops #2631: `api/jest.config.js` declares `projects[]`, which shadows the top-level `testMatch` claiming to collect `test/`). A year of green CI, a populated `test/` directory, and a totally broken subsystem.

## Measured effect on that never-run set

Identical scratch config, before and after:

|          | suites failed | tests failed |
|----------|---------------|--------------|
| before   | 9 / 11        | 55 / 107     |
| after    | 9 / 11        | **25** / 107 |

**30 of the 55 failures were this single import.** The remaining 25 are unrelated pre-existing rot — a missing `chai` devDep, a schema/fixture fault, two auth failures — and belong to ops #2631's decision, not here.

## Tests

`api/tests/services/orchestrator.logger.test.js`, placed under `tests/` so that it **actually runs**, unlike the suites that should have caught this.

It asserts on **construction**, not on the import site: a future refactor may legitimately move the factory or add `createLogger` to `config/logging`. What must never come back is a module in this directory that throws when instantiated. It also pins a non-zero module count — an emptied or moved directory would otherwise make `it.each` vanish and the suite pass by testing nothing.

**Fire-tested.** Committed first, then re-injected the original import into `dependencyAnalyzer.js` alone. 3 of the 6 construct-tests went red — `dependencyAnalyzer`, plus `index` and `taskExecutionEngine`, which construct it transitively — failing on exactly the `createLogger is not a function` assertion. The `requires without throwing` tests stayed green throughout, correctly documenting that `require` is silent about this. Restored from a `cp` backup (not `git checkout`), re-ran with `--no-cache`, and asserted against the **loaded** module rather than the file's text.

Full api suite: **20 suites, 200 tests, green.**

## Not done / deferred / unverified

- I did **not** hit a live `/api/v2` orchestration endpoint to observe a 500. The construction-time throw is measured; the production 500 is a one-step inference from the mount chain.
- I did not check whether the deployed container exposes these routes or whether anything calls them — this may be dead-in-practice as well as broken. If so, the fix is still right, and ops #2631's option (a) will keep it that way.
- The remaining 25 failures in the never-run set are untouched here.
- Two logger modules with overlapping roles (`config/logging.js`, `utils/logger.js`) still coexist; which is canonical is undetermined and may deserve its own card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
