### PR TITLE
fix(dashboard): bump nanoid 3.3.16 → 3.3.18 to clear GHSA-2v37-7h3g-55p8 (unblocks main)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -7484,9 +7484,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
**`main` is currently RED.** This unblocks it, and unblocks PR #220.

## The failure

```
[dashboard] high advisory GHSA-2v37-7h3g-55p8 in nanoid is not allowlisted:
nanoid: custom generators can loop indefinitely when size is zero
```

Confirmed **on `main` itself** — run [31219506518](https://github.com/festion/homelab-gitops/actions/runs/31219506518), job `Dependency Vulnerability Check` — not merely on a feature branch. So this is a newly-published advisory landing on an unchanged tree, not something a PR introduced.

It began blocking in a ~17-minute window today: PR #219 passed this exact check at 21:00, PR #220 failed it at 21:17 against an identical audit surface.

## The fix

A pure lockfile bump is sufficient. The advisory range is `<3.3.17`; both 3.3.17 and 3.3.18 satisfy the `^3.3.16` that **postcss** — the only dependent — already declares. No major upgrade, no `package.json` change, no allowlist entry. Same shape as the js-yaml finding in ops #2622.

The diff is 3 lines: `version`, `resolved`, `integrity`. Nothing else moves.

## Why not `npm audit fix`

Tried first and backed out. It left nanoid **untouched** and instead bumped react-router 7.18.1 → 7.18.2 — ops #2261's territory, and it interacts with the gate's existing react-router allowlist.

Worse, it reported **"found 0 vulnerabilities"** while nanoid was still vulnerable, because the run omitted dev dependencies and nanoid arrives through postcss. A false all-clear in the reassuring direction. `npm update nanoid --package-lock-only` is the surgical equivalent and is what this PR used.

(Also worth noting the standing rule against `npm audit fix --force` — not used here.)

## Verification

Against the **real gate script**, not bare `npm audit`, with both controls:

| lockfile | `./scripts/ci-audit-gate.sh dashboard high` |
|----------|---------------------------------------------|
| pre-fix  | **exit 1** |
| post-fix | **exit 0** |

The negative control matters: without it, a gate that passes proves nothing about whether it can still fail.

All four CI-gated workspaces pass afterwards:

```
.  PASS      api  PASS      dashboard  PASS      mcp-servers  PASS
```

## Not done / deferred / unverified

- The react-router advisory `GHSA-qwww-vcr4-c8h2` remains, and remains allowlisted by the gate's own entry until 2026-10-31. Untouched here; the real fix is ops #2261's React 19 + Node 22 migration.
- I did not audit whether other repos in the org carry a vulnerable nanoid — this PR is scoped to unblocking `main` here.
- The gate's `moderate`-level invocations in `gitops-audit.yml` were not exercised locally; only the `high` level that `ci.yml` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
