### PR TITLE
test(api): collect api/test/ for the first time (ops #2631)

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -12,9 +12,17 @@ module.exports = {
   ],
   
   // Test file patterns
+  //
+  // ops #2631: '<rootDir>/test/**/*.test.js' used to sit here and read as
+  // "api/test/ is collected". It never was. When `projects` is defined (see
+  // below) jest uses each project's own testMatch and IGNORES this top-level
+  // one, so the entry was dead config that advertised coverage nobody had.
+  // Both it and `projects` were introduced by the same commit (fc07af5,
+  // 2025-07-19), so those 11 files had never executed under any committed
+  // configuration. api/test/ is now collected by the 'Legacy API Tests'
+  // project, which is the only thing that can actually collect it.
   testMatch: [
     '<rootDir>/tests/**/*.test.js',
-    '<rootDir>/test/**/*.test.js',
     '**/__tests__/**/*.js'
   ],
   
@@ -146,6 +154,48 @@ module.exports = {
       ],
       setupFilesAfterEnv: [
         '<rootDir>/tests/setup/jest.setup.js'
+      ]
+    },
+    // ops #2631: api/test/ finally gets a project that collects it.
+    //
+    // It is a SEPARATE project on purpose. These suites need config the three
+    // projects above must not inherit, and keeping them isolated means nothing
+    // here can disturb the 200 tests that already pass.
+    //
+    // The quarantine list below is deliberate and each entry names its card.
+    // ops #2312 is the warning: the five root suites were wired up, went
+    // permanently red, and nobody read them again. A suite that cannot pass
+    // yet is quarantined by name rather than left to rot the signal -- but it
+    // is quarantined VISIBLY, in the config, not by a glob that silently
+    // fails to match.
+    {
+      displayName: 'Legacy API Tests',
+      testMatch: [
+        '<rootDir>/test/*.test.js'
+      ],
+      testPathIgnorePatterns: [
+        // ESM-only dependencies (@octokit/webhooks, chokidar). Not fixable by
+        // transformIgnorePatterns -- api declares a babel-jest transform while
+        // babel-jest/@babel/core/@babel/preset-env are all absent and no babel
+        // config exists, so the transform is inert. See ops #2659.
+        '<rootDir>/test/webhook-handler.test.js',
+        '<rootDir>/test/webhook-integration.test.js',
+        '<rootDir>/test/websocket-server.test.js',
+        // Needs chai + sinon, neither of which is a dependency. ops #2660.
+        '<rootDir>/test/coordination.test.js',
+        // Runs, but all 27 fail: the fixture's DDL trips SQLITE_ERROR
+        // "incomplete input" on a BEGIN/END trigger. ops #2660.
+        '<rootDir>/test/metrics.test.js',
+        // Run with real assertion failures -- 18 / 8 / 3 respectively. These
+        // are the ones most likely to be describing genuine defects, the way
+        // ops #2653 turned out to be. ops #2660.
+        '<rootDir>/test/compliance-service.test.js',
+        '<rootDir>/test/orchestrator.test.js',
+        '<rootDir>/test/auth.test.js'
+      ],
+      setupFilesAfterEnv: [
+        '<rootDir>/tests/setup/jest.setup.js',
+        '<rootDir>/tests/setup/database.setup.js'
       ]
     }
   ],

--- a/api/test/metrics.test.js
+++ b/api/test/metrics.test.js
@@ -31,7 +31,7 @@ describe('Metrics System Tests', () => {
     let storage;
     let metricsService;
 
-    before(async () => {
+    beforeAll(async () => {
         // Setup test database
         testDbPath = path.join(__dirname, 'test_metrics.db');
         if (fs.existsSync(testDbPath)) {
@@ -55,7 +55,7 @@ describe('Metrics System Tests', () => {
         metricsService = new MetricsService(mockConfig, storage);
     });
 
-    after(async () => {
+    afterAll(async () => {
         if (storage) {
             await storage.close();
         }

--- a/api/test/monitoring.test.js
+++ b/api/test/monitoring.test.js
@@ -158,7 +158,6 @@ class TestUtils {
 }
 
 // Test suites (commented out for basic validation, use test runner for full tests)
-/*
 describe('Pipeline Health Monitor Tests', () => {
   let healthMonitor;
   let mockServices;
@@ -298,7 +297,13 @@ describe('Pipeline Health Monitor Tests', () => {
   });
 
   describe('Alerting', () => {
-    it('should send alerts for critical health issues', async () => {
+    // QUARANTINED -- ops #2657. Not a test defect: a repository with a 100%
+    // pipeline failure rate over 3 runs scores 79.0 and is classified
+    // 'warning', and checkThresholds only alerts on 'warning' below 75, so no
+    // alert is ever sent. Measured: 20 failing runs -> 70.0 -> alerts fire.
+    // Volume, not health, decides whether the outage is reported. Re-enable
+    // when #2657 lands; this test is correct and the code is not.
+    it.skip('should send alerts for critical health issues', async () => {
       // Mock critical health scenario
       mockServices.metrics.getPipelineRuns = async () => [
         TestUtils.createMockRun({ conclusion: 'failure' }),
@@ -671,7 +676,6 @@ describe('Monitoring Service Integration Tests', () => {
     });
   });
 });
-*/
 
 // Test runner
 async function runTests() {


### PR DESCRIPTION
Delivers ops #2631 option (a), staged: wire the directory in, enable what can pass, quarantine the rest **visibly** with a card each.

## The dead config

`api/jest.config.js` declared:

```js
testMatch: [ '<rootDir>/tests/**/*.test.js',
             '<rootDir>/test/**/*.test.js',    // <-- dead
             '**/__tests__/**/*.js' ]
```

while also defining `projects`. **When `projects` is present, jest uses each project's own `testMatch` and ignores the top-level one** — and all three projects matched only `tests/**`. That middle entry was dead config advertising coverage nobody had.

Both `projects` and that glob arrived in the **same commit** (`fc07af5`, 2025-07-19), and 9 of the 11 files in `api/test/` were added by that commit too. There was no `api/jest.config.js` and no `jest` block in `api/package.json` before it. So these files **never executed under any committed configuration** — not "stopped running", never ran.

## Enabled — 3 of 11

| suite | result |
|---|---|
| `monitoring.test.js` | 33 pass, 1 skipped |
| `pipeline-service.test.js` | pass |
| `wiki-agent.test.js` | pass |

**`monitoring.test.js` needed no code fix at all.** Its entire 513-line test body sat inside a block comment (lines 161–674, *"commented out for basic validation"*), so it registered zero tests. Removing two comment markers recovered 34 real tests.

The 34th is `it.skip`-ed with a comment naming **ops #2657**, and it is *not* a test defect: a repo with a 100% pipeline failure rate over 3 runs scores 79.0 and is classified `warning`, while `checkThresholds` only alerts on `warning` below 75 — so nothing fires. Measured across the range, 20 failing runs scores 70.0 and *does* alert. **Volume, not health, decides whether a total outage is reported.** The test is right; the code is wrong.

## Quarantined — 8 of 11

Each named in `testPathIgnorePatterns` with its blocker and card (**ops #2660**):

- **3 on ESM-only deps** (`@octokit/webhooks`, `chokidar`) — blocked by **ops #2659**: the declared `babel-jest` transform is inert, because `babel-jest`, `@babel/core` and `@babel/preset-env` are all absent and no babel config exists. `transformIgnorePatterns` does not help — un-ignoring a file only routes it to a transform that cannot convert ESM.
- **1 on missing `chai` + `sinon`**
- **1 on a fixture DDL fault** — `metrics.test.js`, all 27 fail on `SQLITE_ERROR: incomplete input` from a `BEGIN/END` trigger
- **3 with 29 real assertion failures** — `compliance-service` 18, `orchestrator` 8, `auth` 3

`metrics.test.js` also gets Mocha `before`/`after` → `beforeAll`/`afterAll`. That does not make it pass, but it moves it from "does not parse" to "runs and fails", which is the honest state.

**Why quarantine rather than enable-and-go-red:** ops #2312 records the five root suites being wired up, going permanently red, and never being read again. A suite that cannot pass yet is excluded *visibly, in config* — not by a glob that silently fails to match.

## Isolation

`Legacy API Tests` is a **separate project on purpose**. These suites need config the other three must not inherit, so nothing here can disturb the 202 tests already passing. That was the design constraint that made staging possible at all.

## Result

```
before   21 suites, 202 tests
after    24 suites, 267 tests   (266 pass, 1 skipped)
```

**+65 tests now actually observed.** The baseline was measured by running `HEAD`'s own `jest.config.js`, not inferred.

**Fire-tested:** breaking the new project's `testMatch` to a non-matching glob drops collection back to exactly 21 suites / 202 tests with zero `test/` files — so the gain demonstrably comes from this project and not from somewhere else. Restored from a `cp` backup, and the 3/8 split asserted against the **loaded** config rather than the file's text. (That assertion caught a real error: I had written "7 quarantined" in the commit message and the follow-up card. It is 8. Both corrected.)

## Found while doing this

Three live defects came out of running suites that had never run, which is the argument for option (a) over deleting them:

- **ops #2653** — the whole `services/orchestrator` subsystem threw on construction (merged, PR #220)
- **ops #2657** — the alerting gap above
- **ops #2656** — `PipelineHealthMonitor` reads `MONITORED_REPOSITORIES` from `process.env` with no default while three sibling services use `config.get` with fallbacks

## Not done / deferred / unverified

- 8 of 11 suites remain unrun. That is the point of ops #2660, not a silent gap — but the directory is still mostly uncovered.
- The 29 assertion failures were categorised by error class only; I did not read what any individual assertion claims. Given #2653, some may be describing real defects.
- I did not check whether `compliance-service`'s 18 failures share a root cause the way the orchestrator's 37 did.
- No coverage thresholds were added for the new project; it contributes tests but gates nothing.
- ops #2659 (the inert babel transform) is filed but untouched — its fix changes how all 200+ green tests compile and needs its own measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
