### PR TITLE
fix(deps): override test-exclude to 7.x in dashboard (ops #2632)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8991,17 +8991,40 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -69,6 +69,7 @@
     "postcss": "^8.5.23",
     "axios": "^1.18.0",
     "brace-expansion": "^5.0.9",
-    "minimatch": "^10.2.1"
+    "minimatch": "^10.2.1",
+    "test-exclude": "^7.0.2"
   }
 }


### PR DESCRIPTION
Second **live** instance of the ops #2630 bug. Found by running that card's sweep against the sub-workspaces instead of only the root tree — the gap ops #2632 names in its own *Unverified* section.

## The defect

`dashboard/` had the identical shape to root:

| | test-exclude | minimatch | |
|---|---|---|---|
| root | 7.0.2 | 10.2.4 | ✅ fixed by #218 |
| api/ | 7.0.2 | 10.2.4 | ✅ reference pairing |
| **dashboard/** | **6.0.0** (declares `^3.0.4`) | **10.2.5** | 🔴 broken |
| mcp-servers/ | absent | 10.2.4 | n/a |
| scripts/ | absent | — | n/a |

There is **no nested `test-exclude/node_modules/minimatch`** to satisfy the declared range — checked, not assumed. That absence *is* the defect; with a nested v3 copy this would be harmless. `test-exclude@6` does `require('minimatch')` and calls the module as a function, which v10 does not export.

The cause is dashboard's **own** unscoped `"minimatch": "^10.2.1"` override, forcing v10 across its whole tree including into `test-exclude@6`'s `^3` requirement. So #2632's premise generalises past root: each sub-workspace carries its own override block, and a root-scoped sweep structurally cannot see them.

## Reproduced, not inferred from the lockfile

**Before:**
```
test-exclude 6.0.0
  plain glob **/*.test.tsx        TypeError: minimatch is not a function
  BRACE glob **/*.{spec,test}.tsx TypeError: minimatch is not a function
```

**After:**
```
test-exclude 7.0.2
  plain glob **/*.test.tsx        OK -> shouldInstrument=false
  BRACE glob **/*.{spec,test}.tsx OK -> shouldInstrument=false
```

`test-exclude@7.0.2` declares `^10.2.2` against a resolved `10.2.5` — declared and resolved finally agree.

## ⚠ This corrects ops #2632

That card records the #2630 variant as firing *"only on glob patterns containing braces"*. **In dashboard it fires on plain globs too** — the failure is unconditional here, so the exposure is wider than that framing implies.

## Choices

- **Caret-bounded to `<8`**, matching the root fix. An unbounded floor resolves the next major just as readily and fails at reinstall time, with CI going green→red on zero commits.
- **Override rather than pinning `minimatch` back to `^3`**, per #2632's rule 3: pinning one legacy package drags its whole legacy chain, and that is exactly how the first #2630 attempt reintroduced the bug via `brace-expansion`. `api/` is the existence proof that `babel-plugin-istanbul` + `test-exclude@7` works (186 tests under coverage).

## Verification

vitest **56 passed / 10 skipped**, build clean.

**Neither is evidence for this fix.** Dashboard's `test` script is `vitest run`, which never traverses the `test-exclude` path — and per #2632, *a green suite does not clear this class*. They are regression checks only. The repro above is the evidence.

## Not done / unverified

- Only the `test-exclude`/`minimatch` pair was swept in the sub-workspaces. Dashboard's other ~7 overrides (`picomatch`, `brace-expansion`, `yaml`, `postcss`, `axios`, `follow-redirects`, `flatted`) are **not** range-checked against their consumers, and neither are api/ or mcp-servers/.
- The 5 UNVERIFIED root entries on #2632 (`uuid` ×2, `@modelcontextprotocol/sdk`, `@anthropic-ai/claude-code`, `shell-quote`) are untouched. The two `uuid` ones remain the most suspicious, and `node-cron` is a runtime dependency — production, not test-only.
- I did not check which advisory dashboard's `minimatch ^10.2.1` was added for, nor whether it is now redundant.

ops #2632