### PR TITLE
chore(deps): drop claude-auto-commit and its vestigial override (ops #2632)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/react": "^19.1.3",
         "@types/react-dom": "^19.1.3",
         "babel-jest": "^30.4.1",
-        "claude-auto-commit": "^0.1.4",
         "jest": "^29.7.0",
         "jest-html-reporters": "^3.1.7",
         "jest-junit": "^17.0.0",
@@ -53,142 +52,6 @@
         "node": ">=18.0.0",
         "npm": ">=8.0.0"
       }
-    },
-    "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.199.tgz",
-      "integrity": "sha512-iQzR49drod55y9NiJHTWt7vSSO85LDvMymEzpO+RTDar+TCsNbE2d2+dj1O57D2rWVA5z0Qhqv0j3K0LvY1exA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "SEE LICENSE IN README.md",
-      "bin": {
-        "claude": "bin/claude.exe"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.199",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.199",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.199",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.199",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.199",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.199",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.199",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.199"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.199.tgz",
-      "integrity": "sha512-i3xy/5XCgV+fQmgMQHDkqLp5JuP0/WGpAXxXirQOprcnkXlY/UreKq51AZHxxFDL3VMBYoDVQXIdtTsfPGiUoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.199.tgz",
-      "integrity": "sha512-cOlldAg86dYz93ZsIEGAR4iE8DUxV0jpyg1E1GVbTBm5gvZNEbZcYbWKH9lXryLL+8Rv3k2HEWJOhaSNsFl1mg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.199.tgz",
-      "integrity": "sha512-snzvmCrPqlX62c1YkKbhvVyWIgyd/4yiouggFwOvTks/+J3imPv5FlKS8cl2x8x3SmqYC0t1XuOnHSNdKRI+sQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.199.tgz",
-      "integrity": "sha512-WaFER1PIzt7V2t73WgW8UdvjYkJ9KLwxZQ6JpE+uZod1qTc3n9HOxQeBbSn1wmp3lAkvUS70W9prJlb4C4ScDQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.199.tgz",
-      "integrity": "sha512-FyyCu9BtG1UL/6aBjSsW55saPsN4MZm0OjeI61/Uql44kuD3DmmVO7IhqE/pq1jFxCPep9SHibg3ehigJhMyZw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.199.tgz",
-      "integrity": "sha512-vW8S1RP9buIVMNiTrdXmF6/ZHWEoEXyWJ0NBVtQLxzDr6iwaCMAeuKredMnNhq9lqZNwLR+nzBqkJ6xAO1XcOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.199.tgz",
-      "integrity": "sha512-CWmagMDlBOWmeiIwJgJvpo0dGCyVHS7aDG5HqxSMPEKka8b5yvYqU/Q83/jmRDQ5nAVWpMF+eJInRmpiQW/I1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.199",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.199.tgz",
-      "integrity": "sha512-MgYGXHqJxsFcXPoRPFrc5c1qv3Y/m8v0v/ngxmd4YeyGvTCgEOySJyNwQIsVz3EvE+AtLG35OEqIIZubhLJgkw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -5888,26 +5751,6 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/claude-auto-commit": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/claude-auto-commit/-/claude-auto-commit-0.1.4.tgz",
-      "integrity": "sha512-zgSeuP5kR8F2kbpmhRaA2nMYOolvVXM81ky9KzKa0X5hzut6UAjD+rt4AQDZKeYz+BEgGqVe/6jFPIEdDR07tA==",
-      "dev": true,
-      "license": "MIT",
-      "os": [
-        "darwin",
-        "linux"
-      ],
-      "dependencies": {
-        "@anthropic-ai/claude-code": "^1.0.22"
-      },
-      "bin": {
-        "claude-auto-commit": "bin/claude-auto-commit"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "install:all": "npm install && npm run install:api && npm run install:dashboard",
     "install:api": "cd api && npm install",
     "install:dashboard": "cd dashboard && npm install",
-    "commit": "npx claude-auto-commit",
-    "commit:dry": "npx claude-auto-commit --dry-run",
     "discovery:start": "node scripts/wiki-discovery-cron.js start",
     "discovery:stop": "node scripts/wiki-discovery-cron.js stop",
     "discovery:status": "node scripts/wiki-discovery-cron.js status",
@@ -74,7 +72,6 @@
     "@types/react": "^19.1.3",
     "@types/react-dom": "^19.1.3",
     "babel-jest": "^30.4.1",
-    "claude-auto-commit": "^0.1.4",
     "jest": "^29.7.0",
     "jest-html-reporters": "^3.1.7",
     "jest-junit": "^17.0.0",
@@ -86,7 +83,6 @@
     "typescript": "^5.8.3"
   },
   "overrides": {
-    "@anthropic-ai/claude-code": "^2.1.84",
     "uuid": "^14.0.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@isaacs/brace-expansion": "^5.0.1",


### PR DESCRIPTION
`claude-auto-commit` has been **broken since 2025-12-11** and nobody noticed, because nobody runs `npm run commit`. Removing it is a better fix than repairing it — and it retires the override that broke it.

## What was broken

```
$ node node_modules/claude-auto-commit/src/claude-auto-commit.js --dry-run
Error: Cannot find package '.../@anthropic-ai/claude-code/index.js'
  imported from .../claude-auto-commit/src/claude-auto-commit.js
    at legacyMainResolve (node:internal/modules/esm/resolve:205:26)
exit code = 1
```

`@anthropic-ai/claude-code@2.1.199` has **no `main`, no `module`, no `exports`** — its `files` are `bin/claude.exe`, `install.cjs`, `cli-wrapper.cjs`, `sdk-tools.d.ts`. **v2 is a CLI-only package with no importable entry point**, while `claude-auto-commit` does `import { query } from "@anthropic-ai/claude-code"`.

The `query()` library surface moved to a **different package**, `@anthropic-ai/claude-agent-sdk`. This is a package split, not a version bump — **no override value can satisfy that import**, so "pin it to a working version" was never on the table.

## Why the override goes too

`git log -S` traces it to `0c37d30` (2025-12-11, *"resolve 14 Dependabot security vulnerabilities"*): `claude-auto-commit` pinned a vulnerable v1 of `claude-code`, and the override forced v2 to clear the advisory. **It cleared the advisory and broke the tool in the same stroke.**

`claude-auto-commit` was its **only** consumer — verified by walking the lockfile for anything declaring `@anthropic-ai/claude-code`, and by grepping the repo for source references (only `package.json` itself). With the package gone the override protects nothing, so removing it **is** the security fix: it deletes the vulnerable dependency rather than forcing an incompatible version onto it.

That also answers ops #2632's standing *"does this override still earn its keep?"* question for one of the twenty.

## The scripts

`npm run commit` / `commit:dry` both ran `npx claude-auto-commit`. Removed with it — the documented commit workflow here is `git shipit`, and the `npx` invocation is separately against the local no-npx supply-chain rule.

## Verification

- **0** lockfile entries and **0** `node_modules` directories match `claude-auto-commit` or `claude-code`.
- **`@modelcontextprotocol/sdk` override preserved deliberately** — it has a real consumer (`@mcp/server-github`) that #2632 verified SAFE. The edit script *asserts* it survives rather than trusting the change.
- **No other resolution moved.** `test-exclude` 7.0.2 (from #218), `minimatch` 10.2.4, `uuid` 14.0.0, sdk 1.29.0, `shell-quote` 1.10.0, `node-cron` 3.0.3, `natural` 6.12.0, `concurrently` 9.2.3 — all byte-identical to before.
- **Re-ran the live probes afterwards**, since removing an override can silently shift resolution elsewhere: `uuid` `v4()`, `node-cron`'s `uuid.v4()` name path, `shell-quote` `quote()`, and the SDK's deep subpaths + named exports all still work.

## Not done / unverified

- I did not check whether the **other 18** root overrides still earn their keep — that's the rest of ops #2632.
- The Node floor for `uuid@14` remains unbounded empirically: it needs `require(esm)` (Node ≥20.19 / ≥22.12) and declares **no `engines`**, so a downgrade would break `node-cron` and `natural` with no install-time warning. Both interpreters available here (prod 20.20.2, dev 22.23.1) are above the line.

ops #2632