### PR TITLE
chore(ci): pin deploy SSH to its own key with IdentitiesOnly (ops #2638)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,6 +127,25 @@ jobs:
     env:
       PROD_HOST: gitopsdashboard.mgmt.lakehouse.wtf
       PROD_USER: root
+      # ops #2638. `ssh -i` does NOT isolate a key — it APPENDS to the
+      # identities ssh would already offer, so the calls below could succeed
+      # on a different credential than the one they name, and nothing in the
+      # config text would say which. That is the #2003 runner-roulette shape
+      # the comment above describes as fixed: self-containment stopped the
+      # deploy DEPENDING on a pre-placed key, but did not stop it OFFERING
+      # one. Nothing is at rest on the runners today (ops #2609 removed it),
+      # so this is safe by circumstance; IdentitiesOnly makes it safe by
+      # construction.
+      #
+      # Defined here rather than per call site so an added invocation
+      # inherits the isolation instead of silently omitting it. The tilde is
+      # left unexpanded by the shell and resolved by ssh itself, so it must
+      # not be quoted at the call sites.
+      #
+      # Scope: IdentitiesOnly=yes excludes the DEFAULT identities, not keys
+      # named in an ssh *config* — genuine isolation only while the runner
+      # has no ~/.ssh/config.
+      SSH_OPTS: "-i ~/.ssh/deploy_key -o IdentitiesOnly=yes"
       ARTIFACT_NAME: deployment-package-${{ github.sha }}
       TARBALL: homelab-gitops-auditor-${{ github.sha }}.tar.gz
     steps:
@@ -148,13 +167,13 @@ jobs:
 
       - name: Ship tarball to prod
         run: |
-          scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new \
+          scp $SSH_OPTS -o StrictHostKeyChecking=accept-new \
             "$TARBALL" \
             "$PROD_USER@$PROD_HOST:/tmp/$TARBALL"
 
       - name: Atomic-swap install on prod
         run: |
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new "$PROD_USER@$PROD_HOST" bash -se << EOF
+          ssh $SSH_OPTS -o StrictHostKeyChecking=accept-new "$PROD_USER@$PROD_HOST" bash -se << EOF
           set -euo pipefail
 
           INSTALL_DIR=/opt/gitops


### PR DESCRIPTION
Last of the repos in ops #2638. A direct refinement of the **#2003 runner-roulette fix that this job's own comment describes**.

That fix made the job self-contained so it no longer *depends* on a pre-placed runner key. It did not stop it *offering* one: `ssh -i` does **not** isolate a key — it *appends* to the identities ssh would already offer. So `scp`/`ssh` here could still succeed on a different credential than the one they name, and nothing in the config text would say which.

## Why it is not urgent, and why it still matters

Safe today **by circumstance, not by construction**: ops #2609 removed the default identity from both self-hosted runners and a `PRIVATE KEY` sweep returns zero on each. The moment anything places a key there again — the `github-runner` ansible role (ops #2004), a rebuild, a manual fix — the append silently resumes and deploys keep working, possibly on the wrong credential. Untangling that last time took sshd auth-log forensics, because the config text cannot tell you which key was actually used.

## Change

`SSH_OPTS` added to the `deploy-homelab` job's **existing** `env:` block, so an added invocation inherits the isolation instead of silently omitting it. Two call sites (`scp` of the tarball, `ssh` for the atomic swap).

```yaml
SSH_OPTS: "-i ~/.ssh/deploy_key -o IdentitiesOnly=yes"
```

The `ubuntu-latest` build job does no ssh and is untouched.

## On the unquoted tilde

The value must stay **unquoted** at the call sites. Verified rather than assumed:

- bash word-splits `$SSH_OPTS` into 4 args and leaves `~/.ssh/deploy_key` literal — parameter expansion does not re-run tilde expansion.
- **ssh itself** expands it. Negative control: `ssh -i "~/.ssh/definitely_absent_key"` warns `Identity file /home/dev/.ssh/definitely_absent_key not accessible` — naming the *expanded* path.

## Verification

- `bash -n` over **all 10** `run:` blocks in both jobs passes. Fire-tested: a copy with one unbalanced quote is reported **clean** by yamllint while `bash -n` fails the exact block — so the check discriminates rather than just passing. This matters more than usual here: the `ssh` call feeds a `bash -se << EOF` heredoc.
- yamllint error count **unchanged at 31** before and after (all pre-existing).

## Scope caveat (inherited, not introduced)

`IdentitiesOnly=yes` excludes the **default** identities. It does *not* exclude keys named in an ssh **config** — those count as explicitly specified. This is genuine isolation only while the runners have no `~/.ssh/config` (verified absent on .182 and .183 on 2026-08-07). If one is ever added this weakens silently and nothing will say so.

## Not done / unverified

- **The deploy itself has not been exercised.** `deploy-homelab` runs on push to `main` / `workflow_dispatch`, and this PR does not trigger it — the merge is the real test. It ships to a shared staging dir and atomically swaps, so a failure is visible rather than silent.
- `bash -n` runs on the **template** text, before GitHub expands `${{ secrets.* }}`.
- I did not verify runner `~/.ssh/config` absence today; that reading is carried from 2026-08-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)