### PR TITLE
fix(compliance): the Apply Templates path never ran the applicator (ops #2716/#2717)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,50 @@
+name: Python Tests
+
+# ops #2717: the repo had 14 workflows and NONE of them ran a Python test.
+# .mcp/test_template_applicator.py (added by PR #227 / ops #2648) therefore
+# could never fail a PR — all 22 checks on that PR were green while its new
+# regression test had not executed. A green PR page implied coverage that was
+# not live, which is the reassuring direction.
+#
+# Deliberately discovers .mcp/test_*.py rather than naming one file, so the next
+# Python test added is covered without anyone remembering to edit this workflow.
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+env:
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  python-tests:
+    name: Python Tests (.mcp)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Setup Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Assert at least one test file exists
+      # A discovery run over zero files exits 0 — indistinguishable from
+      # "all tests passed". Without this guard, deleting or renaming every
+      # test would turn this job green rather than red, which is exactly
+      # the failure class ops #2717 was filed for.
+      run: |
+        count=$(find .mcp -name 'test_*.py' -type f | wc -l)
+        echo "discovered $count Python test file(s) under .mcp/"
+        find .mcp -name 'test_*.py' -type f
+        if [ "$count" -eq 0 ]; then
+          echo "::error::no .mcp/test_*.py found — job would pass vacuously"
+          exit 1
+        fi
+
+    - name: Run tests
+      run: python3 -m unittest discover -s .mcp -p 'test_*.py' -v

--- a/api/services/compliance/templateEngine.js
+++ b/api/services/compliance/templateEngine.js
@@ -323,15 +323,26 @@ class TemplateEngine {
     const { dryRun = true, createPR = false, backupDir = null } = options;
 
     try {
+      // ops #2716: the CLI declares `action` as a REQUIRED positional with
+      // choices {list,validate,apply,analyze}. Omitting it made argparse exit 2
+      // before the applicator was ever reached — so this path had NEVER worked,
+      // on apply or on dry-run (argparse rejects before --dry-run is consulted).
       const args = [
         this.applicatorScript,
+        'apply',
         '--template', templateName,
         '--repository', repositoryPath
       ];
 
-      if (dryRun) {
-        args.push('--dry-run');
-      }
+      // The CLI computes `dry_run = not args.apply` — `--dry-run` is decorative
+      // and ONLY `--apply` makes a run real. Passing neither (the old
+      // dryRun=false path) therefore silently PLANNED and exited 0, which the
+      // caller reads as success. Adding the action positional alone would have
+      // turned that into a green "Successfully applied N template(s)" for a run
+      // that wrote nothing — a worse failure than the exit-2 it replaced.
+      // With --apply, the tool's plan-only refusal (PR #227 / ops #2648)
+      // surfaces as a non-zero exit, which is the intended loud outcome.
+      args.push(dryRun ? '--dry-run' : '--apply');
 
       if (this.verbose) {
         args.push('--verbose');

--- a/api/tests/services/templateEngine.applyArgs.test.js
+++ b/api/tests/services/templateEngine.applyArgs.test.js
@@ -1,0 +1,89 @@
+// ops #2716: the "Apply Templates" path had NEVER executed the applicator.
+//
+// templateEngine built the spawn args as
+//   [script, '--template', name, '--repository', path]
+// but the CLI declares `action` as a REQUIRED positional with choices
+// {list,validate,apply,analyze}. argparse therefore exited 2 before the
+// applicator was reached -- on apply AND on dry-run, since argparse rejects
+// before --dry-run is ever consulted. Reproduced verbatim:
+//   $ python3 .mcp/template-applicator.py --template standard-devops --repository /tmp/tgt
+//   error: the following arguments are required: action        exit=2
+//
+// The second half is subtler and is why this test asserts on ARGV rather than
+// on a boolean. The CLI computes `dry_run = not args.apply`, so `--dry-run` is
+// decorative and only `--apply` makes a run real. Adding the action positional
+// ALONE would have made dryRun=false silently PLAN and exit 0 -- reported to
+// the operator as "Successfully applied N template(s)" for a run that wrote
+// nothing. That is a worse failure than the exit-2 it replaced, and a test that
+// only checked "does it succeed now" would have certified it.
+
+const TemplateEngine = require('../../services/compliance/templateEngine');
+
+describe('TemplateEngine.applyTemplate spawn args (#2716)', () => {
+  let engine;
+  let seenArgs;
+
+  beforeEach(() => {
+    engine = new TemplateEngine();
+    seenArgs = null;
+    // Capture argv instead of asserting only on the returned verdict: the
+    // defect lived entirely in the arguments, and a stub that answers success
+    // to every argv pins nothing.
+    engine.runPythonScript = async (args) => {
+      seenArgs = args;
+      return { exitCode: 0, stdout: '{}', stderr: '' };
+    };
+  });
+
+  it('passes the required `action` positional', async () => {
+    await engine.applyTemplate('/tmp/repo', 'standard-devops', { dryRun: true });
+    expect(seenArgs).not.toBeNull();
+    // Must be the positional, immediately after the script path -- not a flag.
+    expect(seenArgs[1]).toBe('apply');
+  });
+
+  it('does not reintroduce the argparse-rejected invocation', async () => {
+    await engine.applyTemplate('/tmp/repo', 'standard-devops', { dryRun: true });
+    // The exact shape that exited 2: first arg after the script is an option.
+    expect(seenArgs[1].startsWith('--')).toBe(false);
+    expect(['list', 'validate', 'apply', 'analyze']).toContain(seenArgs[1]);
+  });
+
+  it('sends --apply for a real run, so the plan-only refusal can surface', async () => {
+    await engine.applyTemplate('/tmp/repo', 'standard-devops', { dryRun: false });
+    expect(seenArgs).toContain('--apply');
+    // Sending both would be ambiguous about intent even though the CLI ignores
+    // --dry-run; keep the two mutually exclusive.
+    expect(seenArgs).not.toContain('--dry-run');
+  });
+
+  it('sends --dry-run and never --apply for a dry run', async () => {
+    await engine.applyTemplate('/tmp/repo', 'standard-devops', { dryRun: true });
+    expect(seenArgs).toContain('--dry-run');
+    // The positive control for the pair above: a dry run must never be able to
+    // reach the writing path. If this ever passes --apply, a "preview" mutates
+    // the repository.
+    expect(seenArgs).not.toContain('--apply');
+  });
+
+  it('defaults to a dry run when the caller says nothing', async () => {
+    await engine.applyTemplate('/tmp/repo', 'standard-devops');
+    expect(seenArgs).toContain('--dry-run');
+    expect(seenArgs).not.toContain('--apply');
+  });
+
+  it('still carries the template and repository it was given', async () => {
+    await engine.applyTemplate('/tmp/some-repo', 'my-template', { dryRun: true });
+    expect(seenArgs[seenArgs.indexOf('--template') + 1]).toBe('my-template');
+    expect(seenArgs[seenArgs.indexOf('--repository') + 1]).toBe('/tmp/some-repo');
+  });
+
+  it('reports failure when the applicator exits non-zero', async () => {
+    engine.runPythonScript = async (args) => {
+      seenArgs = args;
+      return { exitCode: 1, stdout: '', stderr: 'plan-only tool' };
+    };
+    const result = await engine.applyTemplate('/tmp/repo', 'standard-devops', { dryRun: false });
+    expect(result.success).toBe(false);
+  });
+});

--- a/dashboard/src/components/compliance/ComplianceActions.tsx
+++ b/dashboard/src/components/compliance/ComplianceActions.tsx
@@ -42,18 +42,40 @@ export const ComplianceActions: React.FC<ComplianceActionsProps> = ({
       });
       
       const result = await response.json();
-      
-      if (response.ok) {
+
+      // ops #2716: branching on response.ok alone rendered a green
+      // "Successfully applied N template(s)" for a run in which every template
+      // FAILED — the endpoint answers 200 with an all-failed results array, and
+      // the per-template success flags were never inspected. Derive the verdict
+      // from the body; treat a malformed/absent results array as failure rather
+      // than success, so a shape change can never resurrect the false green.
+      const results = Array.isArray(result?.results) ? result.results : null;
+      const succeeded = results ? results.filter((r: { success?: boolean }) => r?.success === true).length : 0;
+      const allSucceeded = results !== null && results.length > 0 && succeeded === results.length;
+
+      if (response.ok && allSucceeded) {
         setLastResult({
           success: true,
-          message: `Successfully applied ${templates.length} template(s)`,
+          message: `Successfully applied ${succeeded} template(s)`,
           pullRequestUrl: result.pullRequestUrl,
           jobId: result.jobId
         });
-        
+
         // Invalidate queries to refresh data
         queryClient.invalidateQueries({ queryKey: ['compliance'] });
         onSuccess?.();
+      } else if (response.ok) {
+        // 200, but the work did not succeed. Name what actually happened.
+        const failed = results ? results.length - succeeded : 0;
+        const detail = results === null
+          ? 'the server returned no per-template results'
+          : `${failed} of ${results.length} template(s) failed`;
+        const firstError = results?.find((r: { error?: string }) => r?.error)?.error;
+        setLastResult({
+          success: false,
+          message: `Template application failed — ${detail}${firstError ? `: ${firstError}` : ''}`,
+          jobId: result.jobId
+        });
       } else {
         setLastResult({
           success: false,


### PR DESCRIPTION
Closes ops #2716 and ops #2717. **Three** defects, each of which alone makes the button's green meaningless — the third was not in the card and is the one that would have bitten after a "correct" fix.

## 1. The applicator was never reached (exit 2)

`templateEngine.js` built the spawn args with no `action` positional, but the CLI declares it **required** with choices `{list,validate,apply,analyze}`. argparse exits before the applicator runs — on apply *and* on dry-run, since it rejects before `--dry-run` is consulted. Reproduced verbatim:

```
$ python3 .mcp/template-applicator.py --template standard-devops --repository /tmp/tgt
template-applicator.py: error: the following arguments are required: action
exit=2
```

## 2. ⚠ Fixing only that would have made it worse

The CLI computes **`dry_run = not args.apply`** — `--dry-run` is decorative, and only `--apply` makes a run real. The old code pushed `--dry-run` when dry and **nothing** when not. So adding the positional alone would have made a real apply silently *plan* and exit 0, surfacing as a green *"Successfully applied N template(s)"* for a run that wrote nothing — worse than the exit-2 it replaced, because it looks like it works.

Measured both ways:

```
apply … (no --apply)   -> exit=0   plans silently
apply … --apply        -> exit=1   "Template application is not implemented;
                                    this tool is plan-only."   (PR #227 / ops #2648)
```

Now sends `--apply` for a real run, so that refusal is what the operator actually sees — the outcome ops #2716 asked for.

## 3. The UI rendered green over total failure

`ComplianceActions.tsx` branched on `response.ok` alone and never inspected the per-template flags. The endpoint returns **200 with an all-failed results array** — it even computes `results.every(r => r.success)` for its own WebSocket event, so the data was right there. Now the verdict comes from the body, with the failed count and first error surfaced. A malformed or absent `results` array is treated as **failure**, so a response-shape change cannot resurrect the false green.

## ops #2717 — nothing ran Python tests

14 workflows, none running Python. `.mcp/test_template_applicator.py` (added by PR #227) **could never fail a PR** — all 22 checks there were green while its regression test had not executed.

`python-tests.yml` discovers `.mcp/test_*.py` rather than naming a file, and **asserts at least one exists first**: a discovery run over zero files exits 0, which is indistinguishable from "all tests passed". Without that guard, deleting every test turns the job green.

## Tests: 16 → 23, all green

The 7 new tests assert on **argv**, not on a verdict — the defect lived entirely in the arguments, and a stub that answers success to every argv pins nothing.

**Fire-tested:** injecting the original defect fails 3 of them (action positional, no-option-first, `--apply` on a real run). Restored from a `cp` backup, not `git checkout`, and the restored file was re-grepped to confirm the fix was actually back rather than merely appearing reverted.

Includes the positive control that a **dry run must never send `--apply`** — otherwise a "preview" could mutate a repository, and a patch that passed `--apply` unconditionally would satisfy every other assertion here.

## Not done / unverified

- **The real apply still cannot work** — it now fails *loudly* instead of silently, which is the intended state while the applicator is plan-only. Making it actually apply is a separate decision, not this PR.
- `--dry-run` remains a decorative flag on the CLI (`dry_run = not args.apply` ignores it). I did not change the CLI's flag semantics; that's a wider change than this fix warrants.
- The dashboard change is **not** covered by a test — the repo has no React test setup, and standing one up is out of scope here. It was verified by reading the endpoint's response shape, not by execution.
- Python CI is verified by running the job's exact commands locally (1 file discovered, 2 tests, OK); the workflow itself has not yet run on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)