### PR TITLE
fix(ci): align codeql-action pins to v4.37.6 + exclude .github/** from prod deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,14 @@ on:
       - '.claude/**'
       - 'docs/**'
       - '.gitignore'
+      # Same reasoning as the entries above, applied to CI definitions: the
+      # deploy job builds its tarball from api/, dashboard/dist, config/ and
+      # scripts/ only, so a change under .github/ ships a byte-identical
+      # artifact. Without this, every workflow-only change — including each
+      # github_actions dependabot bump — fires a full prod redeploy for no
+      # change, against a shared staging dir whose concurrent-deploy race
+      # caused a live outage on 2026-07-02.
+      - '.github/**'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/security-enhanced.yml
+++ b/.github/workflows/security-enhanced.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: javascript
         config-file: ./.github/codeql/codeql-config.yml
@@ -93,7 +93,7 @@ jobs:
         npm run build
         
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
   container-security:
     name: Container Security Scan
@@ -141,7 +141,7 @@ jobs:
         
     - name: Upload Trivy scan results
       if: steps.image.outputs.built == 'true'
-      uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         sarif_file: 'trivy-results.sarif'
         category: container-image
@@ -214,7 +214,7 @@ jobs:
         exit-code: '0'
 
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         sarif_file: 'trivy-fs-results.sarif'
         # Distinct category. Both this job and the dormant container job upload

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -65,13 +65,13 @@ jobs:
     
     - name: Run CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: javascript
     
     - name: Perform CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
     
     - name: Scan shell scripts with ShellCheck
       run: |


### PR DESCRIPTION
Two CI fixes. Both are workflow-only; neither touches shipped code.

---

## 1. Align all `codeql-action` pins to v4.37.6

The security gate is currently **red on `main`**, not just on PRs. `init` and `analyze` were pinned to different releases:

| subpath | SHA | version |
|---|---|---|
| `init` | `68bde559` | v4.35.4 |
| `analyze` | `5595ccaf` | **v4.37.6** |
| `upload-sarif` (x2) | `68bde559` | v4.35.4 |

`init` writes a config file stamped with its own version; the `analyze` post-action refuses to load a config written by a different version:

```
##[error]Loaded a configuration file for version '4.35.4', but running version '4.37.6'
##[error]analyze post-action step failed: ...
```

Observed on `main` (run `31434715805`, `Enhanced Security Scanning`) and on the dependabot branches (run `31434749249`, `Security Scan`) — not PR-specific, and it predates the current batch.

**Cause:** Dependabot treats `github/codeql-action/init`, `/analyze` and `/upload-sarif` as **three separate dependencies**. It bumped `/analyze` alone and left the other two behind. #237 is the matching `/init` bump — still open, and unmergeable precisely because this failure makes its own checks red.

The trailing comments were `# v4` on **both** SHAs, so a two-version split rendered as no visible change in every diff that produced it. Replaced with exact versions.

## 2. Exclude `.github/**` from the production deploy trigger

`deploy.yml` already skips the prod redeploy for changes that cannot alter the shipped artifact (`**/*.md`, `.claude/**`, `docs/**`, `.gitignore`), and its own comment gives the reason: the deploy job copies api/dashboard/config/scripts only.

`.github/**` meets that same test and was omitted. Verified against the deploy job (`deploy.yml:71-88`) — the tarball is built from `api/`, `dashboard/dist`, `config/`, `scripts/`. `.github/` is never copied.

Without this, **every** workflow-only change fires a full production redeploy for zero change — including all five github_actions dependabot bumps opened 2026-08-10 (#237–#241) — against the shared `/opt/gitops-new` staging dir whose concurrent-deploy race caused a live outage on 2026-07-02. The concurrency group serialises deploys, so this is wasted risk rather than likely breakage, but it is wasted risk on a path with an incident on record.

`workflow_dispatch` ignores paths filters, so a manual deploy of any commit remains available.

---

## Verification

- ✅ `Security Scan` and `Enhanced Security Scanning` — the two jobs that were failing — **pass on this branch**. All 7 runs green on the first commit (`Dependabot auto-merge` correctly `skipped`, not a dependabot PR).
- ✅ Confirmed the `init`, `analyze` and `upload-sarif` subpaths all exist at `5595ccaf`. Negative control: a bogus subpath at the same ref returns 404, so the check discriminates.
- ✅ Both workflow files parse as valid YAML; `paths-ignore` reads back as `['**/*.md', '.claude/**', 'docs/**', '.gitignore', '.github/**']`.
- ⚠️ **Expected but unverified:** because GitHub evaluates a workflow's triggers from the file at the pushed commit, fix 2 should apply to its own merge — this PR touches only `.github/`, so `Deploy to Production` should not run. I'll confirm against the actual merge rather than assume it.

## Not in scope

The `Dependabot auto-merge` job fails separately with `refusing to allow a Personal Access Token to create or update workflow ... without 'workflow' scope`. That is a token-scope problem on `DEPENDABOT_AUTOMERGE_TOKEN`, filed as ops #2775 — it reframes ops #2282, which currently treats the problem as rollout coverage. This PR does not address it, and the five github_actions PRs will still need a manual merge.

Refs ops #2282, ops #2622, ops #2373.