### PR TITLE
fix(deps): group github/codeql-action subpaths so they cannot split

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,29 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      # Dependabot treats each SUBPATH of an action repo as an independent
+      # dependency — github/codeql-action/init, /analyze and /upload-sarif are
+      # three separate `uses:` strings, so it will happily bump one and leave
+      # the others behind. Those three MUST move together: `init` writes a
+      # config file stamped with its own version and `analyze` refuses to load
+      # a config written by a different one.
+      #
+      # This is not hypothetical. On 2026-08-10 PR #234 bumped /analyze alone
+      # to v4.37.6 and auto-merged, leaving /init at v4.35.4. Every security
+      # scan then failed with
+      #   "Loaded a configuration file for version '4.35.4', but running
+      #    version '4.37.6'"
+      # on main and on every PR, for 11 days. The matching /init bump (#237)
+      # could not merge because the split it was meant to repair made its own
+      # checks red. Fixed by hand in #242.
+      #
+      # Grouping is the fix for the CAUSE. The exact-version trailing comments
+      # added in #242 (`# v4.37.6`, not `# v4`) are the fix for the
+      # DETECTABILITY — a split used to render as no visible change in the diff.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "npm"
     directory: "/api"


### PR DESCRIPTION
Fixes the **cause** of the incident #242 repaired by hand.

## What happened

Dependabot treats each **subpath** of an action repo as an independent dependency. `github/codeql-action/init`, `/analyze` and `/upload-sarif` are three distinct `uses:` strings, so it will bump one and leave the others behind.

Those three must move together — `init` writes a config file stamped with its own version, and the `analyze` post-action refuses to load a config written by a different one.

On **2026-08-10, PR #234 bumped `/analyze` alone** to v4.37.6 and auto-merged, leaving `/init` and both `/upload-sarif` pins at v4.35.4:

```
##[error]Loaded a configuration file for version '4.35.4', but running version '4.37.6'
```

Red on `main` and on every PR for **11 days** (2026-07-31 → 2026-08-11).

Two things made it persist:

- **It delayed zero merges.** Only `Unit Tests` and `lint-and-test (20.x)` are required here; the security scans are advisory. So an 11-day-red security gate blocked nothing and nobody had a reason to look.
- **The matching `/init` bump (#237) could not merge either** — the split it was meant to repair made its own checks red. A partial bump that blocks its own completion.

> The automation created the breakage and then could not repair it. That matters for where the fix belongs: **fixing the auto-merge token without fixing the coupling would make partial bumps land _more_ reliably, not less.**

## The change

```yaml
    groups:
      codeql-action:
        patterns:
          - "github/codeql-action*"
```

Plus a comment block recording the incident inline, so the next person to touch this file doesn't have to re-derive why the group exists.

**Grouping fixes the cause. #242's exact-version comments fix the detectability** — before that, both pins read `# v4`, so a two-version split rendered as *no visible change* in the diff; the only differing token was 40 characters of hex.

## Verification

- YAML parses; the group resolves as `{'patterns': ['github/codeql-action*']}` under the `github-actions` ecosystem.
- Pattern fire-tested against the real dependency names — all three subpaths match; `actions/checkout`, `actions/setup-node`, `docker/login-action`, `codecov/codecov-action` and `snyk/actions/node` all correctly **do not**.
- Caveat stated honestly: that test used Python `fnmatch` as a **proxy** for dependabot's matcher. Dependabot documents `*` wildcards so it should behave identically, but the real proof is the next Monday run producing **one** grouped PR instead of three.

## Scope

Deliberately narrow. `codeql-action` is the only genuinely coupled set here — the `docker/*` actions are separate **repositories**, not subpaths, and share no version.

A broader "one PR for all action updates" group would also work, and would additionally damp the five-PRs-in-90-seconds burst implicated in ops #2775 — but that's a larger behavioural change and isn't needed to fix this defect. Easy to add later if the burst turns out to matter.

## Not addressed here

The auto-merge token's intermittent `workflow`-scope failure (ops #2775) is untouched — 4 attempts recorded, 2 failures, mechanism still unknown. This PR makes that less urgent rather than more, since the damaging case was a *successful* auto-merge of a partial bump.

Also unchecked: whether other repos in the org carry `codeql-action` subpaths with the same exposure. This is a one-repo fix.

Refs ops #2775, ops #2372, ops #2373.