### PR TITLE
fix(ci): exclude github_actions from dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,7 +2,8 @@ name: Dependabot auto-merge
 
 # Auto-merges Dependabot patch/minor PRs once the branch-protection required
 # status checks (Unit Tests, lint-and-test) pass. Major version bumps are left
-# for manual review. `--auto` arms the merge but GATES it on those checks, so a
+# for manual review, as is the ENTIRE github_actions ecosystem (see the step
+# comment below). `--auto` arms the merge but GATES it on those checks, so a
 # failing test never merges. Runs only for dependabot-authored PRs.
 #
 # The merge is enabled with a fine-grained PAT (DEPENDABOT_AUTOMERGE_TOKEN, a
@@ -25,10 +26,26 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
+      # github_actions is excluded deliberately, on top of the dependabot.yml
+      # grouping added in #243. Grouping fixes the CAUSE (partial bumps of a
+      # version-coupled set); this is the belt-and-suspenders half.
+      #
+      # Why this ecosystem and not the others: a github_actions bump modifies
+      # the CI system itself — the thing that would catch a bad change. A bad
+      # npm bump gets caught by CI; a bad workflow bump can disable or break
+      # the very checks that would catch it. Demonstrated 2026-08-10: PR #234
+      # auto-merged a codeql-action/analyze bump on its own, leaving /init a
+      # version behind, and every security scan failed for 11 days without
+      # blocking a single merge (only Unit Tests and lint-and-test are
+      # required here — see ops #2373).
+      #
+      # Note the damaging case was a SUCCESSFUL auto-merge, not a failed one.
+      # Every other ecosystem still auto-merges patch/minor as before.
       - name: Enable auto-merge for patch and minor updates
         if: >-
+          steps.metadata.outputs.package-ecosystem != 'github_actions' && (
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Belt-and-suspenders on top of the grouping added in #243.

**#243 fixes the cause** (dependabot splitting a version-coupled set across independent PRs). **This removes the automation from the one ecosystem where an unreviewed merge can disable the checks that would have caught it.**

## Why `github_actions` specifically

A `github_actions` bump modifies **the CI system itself**. A bad npm bump gets caught by CI; a bad workflow bump can break or disable the very checks that would catch it. That's a different risk class, not just a bigger one.

Demonstrated 2026-08-10 — PR #234 auto-merged a `codeql-action/analyze` bump alone, leaving `/init` a version behind:

```
##[error]Loaded a configuration file for version '4.35.4', but running version '4.37.6'
```

Every security scan then failed on `main` and on every PR for **11 days**, and delayed **zero** merges, because only `Unit Tests` and `lint-and-test (20.x)` are required here (ops #2373). The matching `/init` bump couldn't merge either — the split it was meant to repair made its own checks red.

> The damaging event was a **successful** auto-merge, not a failed one. That reframes ops #2775: fixing the token's intermittent workflow-scope error without this would make partial bumps land *more* reliably.

## What is unaffected

**Every other ecosystem still auto-merges patch/minor exactly as before** — npm, docker, and the rest. Only `github_actions` now needs a human. (PR #244, a `ws` npm bump, auto-merged while this branch was being written — that path is untouched.)

## Fail-closed by construction

The condition stays an explicit patch-or-minor allowlist rather than the shorter `!= 'version-update:semver-major'`, so an empty or unrecognised `update-type` does **not** auto-merge. The shorter form would have been one character under the line-length limit and fail-*open*; that trade wasn't worth making.

## Verification

Fire-tested across 9 cases — both directions, not just the blocking one:

| ecosystem | update-type | auto-merge | |
|---|---|---|---|
| github_actions | patch | ❌ blocked | the change |
| github_actions | minor | ❌ blocked | would have stopped #234 |
| github_actions | major | ❌ blocked | already was |
| npm | patch / minor | ✅ merges | **unchanged** |
| docker | patch | ✅ merges | **unchanged** |
| npm | major | ❌ blocked | unchanged |
| npm | *(empty)* | ❌ blocked | fail-closed |
| npm | *(missing)* | ❌ blocked | fail-closed |

YAML parses; the folded condition collapses to the intended single expression.

## Trade-off, stated

`github_actions` bumps now need a human merge — roughly one or two a week at this repo's rate, and they carry the CI supply-chain pins, so they shouldn't be left to rot. That is the cost of the change, not a side effect to discover later.

Refs ops #2775, ops #2373, ops #2372.