### PR TITLE
fix(ci): this repo is PUBLIC — move secret-scan off the self-hosted runner (ops #2889)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,14 +18,35 @@ name: Secret scan
 # CI log and actively misleading if you are reasoning about the findings. Run
 # without it locally when investigating.
 #
-# RUNNER: self-hosted, unlike the public-repo rollout. This repo is PRIVATE,
-# so external forks cannot open pull requests against it and the
-# fork-PR-executes-on-your-infrastructure hazard (ops #2341) does not apply --
-# while Actions minutes on private repos are billed, so self-hosted is the
-# cheaper side of a trade that has no security cost here. The public repos in
-# this same rollout deliberately use GitHub-hosted for the opposite reason.
-# `self-hosted` is the bare label already in use by this org's working
-# workflows (verified: tender's deploy/e2e/test jobs complete on it).
+# RUNNER: ubuntu-latest, like every other public repo in this rollout.
+#
+# ⚠ THIS WAS `self-hosted` UNTIL ops #2889, ON A FALSE PREMISE STATED RIGHT
+# HERE. The previous version of this comment read "This repo is PRIVATE, so
+# external forks cannot open pull requests against it and the
+# fork-PR-executes-on-your-infrastructure hazard (ops #2341) does not apply".
+#
+# festion/homelab-gitops is PUBLIC. Verified two ways rather than one:
+#   GET /repos/festion/homelab-gitops            -> "visibility": "public"
+#   GET /repos/.../actions/permissions/access    -> 422 "Access policy only
+#                                                   applies to internal and
+#                                                   private repositories"
+#
+# So for two days (2026-08-12 22:01Z .. 2026-08-14) this workflow gave anyone
+# who can open a pull request a path to execute their own workflow code on
+# homelab hardware on the LAN, because a `pull_request` run uses the FORK's
+# version of the workflow file. No fork ever triggered it -- the only two
+# pull_request runs were from this repo itself -- but that is luck plus a short
+# window, not a control.
+#
+# The comment identified the right hazard, cited the right ticket, and stated
+# the right rule. It got a FACT wrong, and the reasoning around it read as
+# diligence, which is exactly why review passed it. If you are tempted to move
+# this back to `self-hosted` for the billing argument: that argument applies
+# only to private repos, so re-check `visibility` first -- and note that a
+# gitleaks scan of the working tree has no need of homelab hardware at all.
+#
+# `self-hosted` remains correct for THIS repo's deploy.yml, which is
+# push/workflow_dispatch-triggered and therefore unreachable from a fork PR.
 #
 # NOTE: a green run means "no rule matched", not "this repo is clean".
 # Rule-based scanning structurally misses a credential written in prose or a
@@ -44,7 +65,7 @@ permissions:
 
 jobs:
   gitleaks:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
`secret-scan.yml` is `pull_request`-triggered and ran on **`self-hosted`**. A `pull_request` run uses the **fork's** version of the workflow file — so this gave anyone able to open a PR a path to execute their own code on homelab hardware on the LAN. That is the ops #2341 hazard exactly.

## The cause is a false premise stated in the file itself

```
# RUNNER: self-hosted, unlike the public-repo rollout. This repo is PRIVATE,
# so external forks cannot open pull requests against it and the
# fork-PR-executes-on-your-infrastructure hazard (ops #2341) does not apply
```

**`festion/homelab-gitops` is public.** Verified two ways rather than one:

| probe | result |
|---|---|
| `GET /repos/festion/homelab-gitops` | `"visibility": "public"` |
| `GET /repos/.../actions/permissions/access` | **422** *"Access policy only applies to internal and private repositories"* |

The comment names the right hazard, cites the right ticket, and states the rule correctly. It gets a **fact** wrong — and the reasoning around it reads as diligence, which is why it passed review. The control was defeated by its own documentation.

## Scope: this is the only affected public repo

All four other public repos in the same rollout already use `ubuntu-latest`, exactly as that comment says the public rollout deliberately should:

```
homelab-gitops        self-hosted     <- this PR
ble-discovery-addon   ubuntu-latest
gw4-config-tool       ubuntu-latest
birdnet-gone          ubuntu-latest
token-enhancer        ubuntu-latest
```

A single-repo mistake, not a systemic rollout error.

## Exposure window, and what I am *not* claiming

Live from **2026-08-12 22:01Z** (`fe000f9c`, #250) to now — about **2 days**. **No fork ever triggered it:** the only two `pull_request` runs of this workflow came from this repo itself (`fork: false`). That is a short window plus luck, not a control.

**Not established:** whether *"require approval for first-time contributors"* was gating it. `GET /orgs/festion/actions/permissions/workflow` returns **403** to this token (ops #2720), so the mitigating setting is unreadable from here **in both directions** — I can say neither "it was gated" nor "it was wide open". It should be read in the UI. This fix does not depend on the answer.

## Why `ubuntu-latest` costs nothing here

The job checks out, `curl`s a **pinned, checksum-verified** `linux_x64` gitleaks binary, and scans the working tree. It uses nothing the self-hosted runner provides. The billing argument that motivated `self-hosted` applies only to private repos.

`deploy.yml` **keeps** `self-hosted` and is untouched — it is `push`/`workflow_dispatch`-triggered, so a fork PR cannot reach it. The new comment records that distinction, and tells the next reader to re-check `visibility` before moving this back.

## How it was found

By running `public-selfhosted-runner-watch.py` **by hand**, while acceptance-testing an unrelated fix (ops #2888) in `homelab-iac`. The watcher is healthy and was not at fault: its last scheduled run was **2026-08-10 07:02, `exit=0`**, correctly reporting no violations — two days *before* this landed. Its next run was due **2026-08-17**.

So the gap was the control's **cadence**, not its logic: a public repo gained LAN code execution and the watcher's next look was five days out. Whether a check of this class should be weekly at all is tracked on ops #2889.

## Verification after merge

Re-run the watcher and expect `EXIT_OK`, with `homelab-gitops/deploy.yml` **still listed** as *"self-hosted, no PR trigger (allowed)"* — that second half is the positive control, proving the sweep still sees this repo rather than having stopped scanning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
